### PR TITLE
fix stream errors

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -131,6 +131,10 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 			return fmt.Errorf("unmarshal: %w", err)
 		}
 
+		if errorResponse.Error != "" {
+			return fmt.Errorf("stream: %s", errorResponse.Error)
+		}
+
 		if response.StatusCode >= 400 {
 			return StatusError{
 				StatusCode: response.StatusCode,

--- a/server/images.go
+++ b/server/images.go
@@ -192,7 +192,6 @@ func CreateModel(name string, path string, fn func(status string)) error {
 	fn("parsing modelfile")
 	commands, err := parser.Parse(mf)
 	if err != nil {
-		fn(fmt.Sprintf("error: %v", err))
 		return err
 	}
 
@@ -227,14 +226,12 @@ func CreateModel(name string, path string, fn func(status string)) error {
 				fn("creating model layer")
 				file, err := os.Open(fp)
 				if err != nil {
-					fn(fmt.Sprintf("couldn't find model '%s'", c.Args))
 					return fmt.Errorf("failed to open file: %v", err)
 				}
 				defer file.Close()
 
 				l, err := CreateLayer(file)
 				if err != nil {
-					fn(fmt.Sprintf("couldn't create model layer: %v", err))
 					return fmt.Errorf("failed to create layer: %v", err)
 				}
 				l.MediaType = "application/vnd.ollama.image.model"
@@ -244,7 +241,6 @@ func CreateModel(name string, path string, fn func(status string)) error {
 				for _, l := range mf.Layers {
 					newLayer, err := GetLayerWithBufferFromLayer(l)
 					if err != nil {
-						fn(fmt.Sprintf("couldn't read layer: %v", err))
 						return err
 					}
 					layers = append(layers, newLayer)
@@ -304,7 +300,6 @@ func CreateModel(name string, path string, fn func(status string)) error {
 
 	err = SaveLayers(layers, fn, false)
 	if err != nil {
-		fn(fmt.Sprintf("error saving layers: %v", err))
 		return err
 	}
 
@@ -312,7 +307,6 @@ func CreateModel(name string, path string, fn func(status string)) error {
 	fn("writing manifest")
 	err = CreateManifest(name, cfg, manifestLayers)
 	if err != nil {
-		fn(fmt.Sprintf("error creating manifest: %v", err))
 		return err
 	}
 
@@ -610,7 +604,6 @@ func PullModel(name, username, password string, fn func(api.ProgressResponse)) e
 
 	for _, layer := range layers {
 		if err := downloadBlob(mp, layer.Digest, username, password, fn); err != nil {
-			fn(api.ProgressResponse{Status: fmt.Sprintf("error downloading: %v", err), Digest: layer.Digest})
 			return err
 		}
 	}


### PR DESCRIPTION
once the stream is created, it's too late to update response headers (i.e. status code). any and all errors must be returned by the stream