### PR TITLE
README typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Ollama includes a library of open-source, pre-trained models. More models are co
 | Llama2      | 7B         | 3.8GB | `ollama pull llama2`      |
 | Orca Mini   | 3B         | 1.9GB | `ollama pull orca`        |
 | Vicuna      | 7B         | 3.8GB | `ollama pull vicuna`      |
-| Nous-Hermes | 13         | 7.3GB | `ollama pull hous-hermes` |
+| Nous-Hermes | 13B         | 7.3GB | `ollama pull hous-hermes` |
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Ollama includes a library of open-source, pre-trained models. More models are co
 | Llama2      | 7B         | 3.8GB | `ollama pull llama2`      |
 | Orca Mini   | 3B         | 1.9GB | `ollama pull orca`        |
 | Vicuna      | 7B         | 3.8GB | `ollama pull vicuna`      |
-| Nous-Hermes | 13B         | 7.3GB | `ollama pull hous-hermes` |
+| Nous-Hermes | 13B         | 7.3GB | `ollama pull nous-hermes` |
 
 ## Building
 


### PR DESCRIPTION
- Simple typo fix in README.md
- `13` changed to `13B` (the `B` was missing) on Nous-Hermes model in models table
- Also edited `hous-hermes` to `nous-hermes` (should be n instead of h)