### PR TITLE
fix pull 0 bytes on completed layer

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -160,11 +160,11 @@ func (c *Client) Generate(ctx context.Context, req *GenerateRequest, fn Generate
 	})
 }
 
-type PullProgressFunc func(PullProgress) error
+type PullProgressFunc func(ProgressResponse) error
 
 func (c *Client) Pull(ctx context.Context, req *PullRequest, fn PullProgressFunc) error {
 	return c.stream(ctx, http.MethodPost, "/api/pull", req, func(bts []byte) error {
-		var resp PullProgress
+		var resp ProgressResponse
 		if err := json.Unmarshal(bts, &resp); err != nil {
 			return err
 		}
@@ -173,11 +173,11 @@ func (c *Client) Pull(ctx context.Context, req *PullRequest, fn PullProgressFunc
 	})
 }
 
-type PushProgressFunc func(PushProgress) error
+type PushProgressFunc func(ProgressResponse) error
 
 func (c *Client) Push(ctx context.Context, req *PushRequest, fn PushProgressFunc) error {
 	return c.stream(ctx, http.MethodPost, "/api/push", req, func(bts []byte) error {
-		var resp PushProgress
+		var resp ProgressResponse
 		if err := json.Unmarshal(bts, &resp); err != nil {
 			return err
 		}

--- a/api/types.go
+++ b/api/types.go
@@ -43,26 +43,17 @@ type PullRequest struct {
 	Password string `json:"password"`
 }
 
-type PullProgress struct {
+type ProgressResponse struct {
 	Status    string  `json:"status"`
 	Digest    string  `json:"digest,omitempty"`
 	Total     int     `json:"total,omitempty"`
 	Completed int     `json:"completed,omitempty"`
-	Percent   float64 `json:"percent,omitempty"`
 }
 
 type PushRequest struct {
 	Name     string `json:"name"`
 	Username string `json:"username"`
 	Password string `json:"password"`
-}
-
-type PushProgress struct {
-	Status    string  `json:"status"`
-	Digest    string  `json:"digest,omitempty"`
-	Total     int     `json:"total,omitempty"`
-	Completed int     `json:"completed,omitempty"`
-	Percent   float64 `json:"percent,omitempty"`
 }
 
 type ListResponse struct {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -83,7 +83,7 @@ func push(cmd *cobra.Command, args []string) error {
 	client := api.NewClient()
 
 	request := api.PushRequest{Name: args[0]}
-	fn := func(resp api.PushProgress) error {
+	fn := func(resp api.ProgressResponse) error {
 		fmt.Println(resp.Status)
 		return nil
 	}
@@ -129,25 +129,23 @@ func RunPull(cmd *cobra.Command, args []string) error {
 func pull(model string) error {
 	client := api.NewClient()
 
+	var currentDigest string
 	var bar *progressbar.ProgressBar
 
-	currentLayer := ""
 	request := api.PullRequest{Name: model}
-	fn := func(resp api.PullProgress) error {
-		if resp.Digest != currentLayer && resp.Digest != "" {
-			if currentLayer != "" {
-				fmt.Println()
-			}
-			currentLayer = resp.Digest
-			layerStr := resp.Digest[7:23] + "..."
+	fn := func(resp api.ProgressResponse) error {
+		if resp.Digest != currentDigest && resp.Digest != "" {
+			currentDigest = resp.Digest
 			bar = progressbar.DefaultBytes(
 				int64(resp.Total),
-				"pulling "+layerStr,
+				fmt.Sprintf("pulling %s...", resp.Digest[7:19]),
 			)
-		} else if resp.Digest == currentLayer && resp.Digest != "" {
+
+			bar.Set(resp.Completed)
+		} else if resp.Digest == currentDigest && resp.Digest != "" {
 			bar.Set(resp.Completed)
 		} else {
-			currentLayer = ""
+			currentDigest = ""
 			fmt.Println(resp.Status)
 		}
 		return nil

--- a/server/routes.go
+++ b/server/routes.go
@@ -101,15 +101,10 @@ func pull(c *gin.Context) {
 	ch := make(chan any)
 	go func() {
 		defer close(ch)
-		fn := func(status, digest string, total, completed int, percent float64) {
-			ch <- api.PullProgress{
-				Status:    status,
-				Digest:    digest,
-				Total:     total,
-				Completed: completed,
-				Percent:   percent,
-			}
+		fn := func(r api.ProgressResponse) {
+			ch <- r
 		}
+
 		if err := PullModel(req.Name, req.Username, req.Password, fn); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -129,15 +124,10 @@ func push(c *gin.Context) {
 	ch := make(chan any)
 	go func() {
 		defer close(ch)
-		fn := func(status, digest string, total, completed int, percent float64) {
-			ch <- api.PushProgress{
-				Status:    status,
-				Digest:    digest,
-				Total:     total,
-				Completed: completed,
-				Percent:   percent,
-			}
+		fn := func(r api.ProgressResponse) {
+			ch <- r
 		}
+
 		if err := PushModel(req.Name, req.Username, req.Password, fn); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return


### PR DESCRIPTION
This PR fixes the bug where when the progress bar displays 0B for a layer when the layer already exists:

```
$ ollama pull llama2
pulling manifest
pulling 8daa9615cce30c25...   0% |                                                                                                                                                  | ( 0 B/3.5 GB) [0s:0s]
pulling c929c04af928be41...   0% |                                                                                                                                                  | ( 0 B/3.5 GB) [0s:0s]
pulling cf39c1a5c36937e4... 100% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (3.5/3.5 GB, 53 TB/s)
writing manifest
success
```

```
$ ollama pull llama2
pulling manifest
pulling 8daa9615cce30c25... 100% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (3.5/3.5 GB, 16 TB/s)
pulling c929c04af928be41... 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (547/547 B, 12 MB/s)
pulling cf39c1a5c36937e4... 100% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (225/225 B, 5.0 MB/s)
writing manifest
success
```

Now each layer also correctly reports the layer's size rather than the total bundle size.

Refactor `Pull/PushProgress` into `ProgressResponse` since they share the exact same attributes and remove `Percent` since it's not being used and the caller can easily compute it for themselves