### PR TITLE
windows: fix model pulling

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -854,6 +854,10 @@ func downloadBlob(mp ModelPath, digest string, username, password string, fn fun
 		})
 
 		if completed >= total {
+			if err := out.Close(); err != nil {
+				return err
+			}
+
 			if err := os.Rename(fp+"-partial", fp); err != nil {
 				fn(api.ProgressResponse{
 					Status:    fmt.Sprintf("error renaming file: %v", err),

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -104,6 +105,10 @@ func GetBlobsPath(digest string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		digest = strings.ReplaceAll(digest, ":", "-")
 	}
 
 	path := filepath.Join(home, ".ollama", "models", "blobs", digest)


### PR DESCRIPTION
There are two issues preventing pull from working as expected in Windows.

1. Windows dislikes `os.Rename` when the file is still open. One approach is to close the file before calling rename. The approach taken in this PR is to call `os.Symlink` instead
2. Windows errors when file paths contain `:` so replace the `:` in the digest name with `-`, e.g. `sha256:0123456789abcdef...` with `sha256-0123456789abcdef...`. This is done _only_ for the blob file path. Non-file path instances of this string are unchanged