### PR TITLE
allow pushing/pulling to insecure registries

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -43,6 +43,7 @@ type DeleteRequest struct {
 
 type PullRequest struct {
 	Name     string `json:"name"`
+	Insecure bool   `json:"insecure,omitempty"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
@@ -56,6 +57,7 @@ type ProgressResponse struct {
 
 type PushRequest struct {
 	Name     string `json:"name"`
+	Insecure bool   `json:"insecure,omitempty"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 }

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -70,10 +70,13 @@ func (mp ModelPath) GetFullTagname() string {
 }
 
 func (mp ModelPath) GetShortTagname() string {
-	if mp.Registry == DefaultRegistry && mp.Namespace == DefaultNamespace {
-		return fmt.Sprintf("%s:%s", mp.Repository, mp.Tag)
+	if mp.Registry == DefaultRegistry {
+		if mp.Namespace == DefaultNamespace {
+			return fmt.Sprintf("%s:%s", mp.Repository, mp.Tag)
+		}
+		return fmt.Sprintf("%s/%s:%s", mp.Namespace, mp.Repository, mp.Tag)
 	}
-	return fmt.Sprintf("%s/%s:%s", mp.Namespace, mp.Repository, mp.Tag)
+	return fmt.Sprintf("%s/%s/%s:%s", mp.Registry, mp.Namespace, mp.Repository, mp.Tag)
 }
 
 func (mp ModelPath) GetManifestPath(createDir bool) (string, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -92,7 +92,13 @@ func PullModelHandler(c *gin.Context) {
 			ch <- r
 		}
 
-		if err := PullModel(req.Name, req.Username, req.Password, fn); err != nil {
+		regOpts := &RegistryOptions{
+			Insecure: req.Insecure,
+			Username: req.Username,
+			Password: req.Password,
+		}
+
+		if err := PullModel(req.Name, regOpts, fn); err != nil {
 			ch <- gin.H{"error": err.Error()}
 		}
 	}()
@@ -114,7 +120,13 @@ func PushModelHandler(c *gin.Context) {
 			ch <- r
 		}
 
-		if err := PushModel(req.Name, req.Username, req.Password, fn); err != nil {
+		regOpts := &RegistryOptions{
+			Insecure: req.Insecure,
+			Username: req.Username,
+			Password: req.Password,
+		}
+
+		if err := PushModel(req.Name, regOpts, fn); err != nil {
 			ch <- gin.H{"error": err.Error()}
 		}
 	}()


### PR DESCRIPTION
This change adds the `--insecure` flag to the push/pull commands so that you can push and pull models from local registries.