### PR TITLE
Update client.go — Allow any origin (header)

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -66,7 +66,6 @@ func (c *Client) do(ctx context.Context, method, path string, reqData, respData 
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Access-Control-Allow-Origin", "*")
 
 	for k, v := range c.Headers {
 		req.Header[k] = v
@@ -160,6 +159,8 @@ func (c *Client) Generate(ctx context.Context, req *GenerateRequest, fn Generate
 		if err := json.Unmarshal(bts, &resp); err != nil {
 			return err
 		}
+
+		resp.Header.Set("Access-Control-Allow-Origin", "*")
 
 		return fn(resp)
 	})

--- a/api/client.go
+++ b/api/client.go
@@ -66,6 +66,7 @@ func (c *Client) do(ctx context.Context, method, path string, reqData, respData 
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Access-Control-Allow-Origin", "*")
 
 	for k, v := range c.Headers {
 		req.Header[k] = v


### PR DESCRIPTION
Allows for the API to be run in Google Chrome without disabling the web security features.