### PR TITLE
better error message when model not found on pull

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -131,7 +131,7 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 		}
 
 		if errorResponse.Error != "" {
-			return fmt.Errorf("stream: %s", errorResponse.Error)
+			return fmt.Errorf(errorResponse.Error)
 		}
 
 		if response.StatusCode >= 400 {

--- a/server/images.go
+++ b/server/images.go
@@ -738,8 +738,6 @@ func PullModel(name string, regOpts *RegistryOptions, fn func(api.ProgressRespon
 	return nil
 }
 
-var errModelNotFound = fmt.Errorf("model not found")
-
 func pullModelManifest(mp ModelPath, regOpts *RegistryOptions) (*ManifestV2, error) {
 	url := fmt.Sprintf("%s/v2/%s/manifests/%s", mp.Registry, mp.GetNamespaceRepository(), mp.Tag)
 	headers := map[string]string{
@@ -756,7 +754,7 @@ func pullModelManifest(mp ModelPath, regOpts *RegistryOptions) (*ManifestV2, err
 	// Check for success: For a successful upload, the Docker registry will respond with a 201 Created
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, errModelNotFound
+			return nil, fmt.Errorf("model not found")
 		}
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("on pull registry responded with code %d: %s", resp.StatusCode, body)

--- a/server/images.go
+++ b/server/images.go
@@ -684,7 +684,7 @@ func PullModel(name string, regOpts *RegistryOptions, fn func(api.ProgressRespon
 
 	manifest, err := pullModelManifest(mp, regOpts)
 	if err != nil {
-		return fmt.Errorf("pull model manifest: %q", err)
+		return fmt.Errorf("pull model manifest: %s", err)
 	}
 
 	var layers []*Layer
@@ -738,6 +738,8 @@ func PullModel(name string, regOpts *RegistryOptions, fn func(api.ProgressRespon
 	return nil
 }
 
+var errModelNotFound = fmt.Errorf("model not found")
+
 func pullModelManifest(mp ModelPath, regOpts *RegistryOptions) (*ManifestV2, error) {
 	url := fmt.Sprintf("%s/v2/%s/manifests/%s", mp.Registry, mp.GetNamespaceRepository(), mp.Tag)
 	headers := map[string]string{
@@ -753,6 +755,9 @@ func pullModelManifest(mp ModelPath, regOpts *RegistryOptions) (*ManifestV2, err
 
 	// Check for success: For a successful upload, the Docker registry will respond with a 201 Created
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, errModelNotFound
+		}
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("on pull registry responded with code %d: %s", resp.StatusCode, body)
 	}


### PR DESCRIPTION
```
ollama run orca-dne
pulling manifest
Error: pull model manifest: model not found
```

resolves #180