### PR TITLE
embed ggml-metal.metal

### DIFF
--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -1,1 +1,0 @@
-llama/ggml-metal.metal

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -86,6 +86,7 @@ llama_token llama_sample(
 import "C"
 import (
 	"bytes"
+	"embed"
 	"errors"
 	"fmt"
 	"io"
@@ -98,6 +99,9 @@ import (
 
 	"github.com/jmorganca/ollama/api"
 )
+
+//go:embed ggml-metal.metal
+var fs embed.FS
 
 type LLM struct {
 	params *C.struct_llama_context_params

--- a/llama/llama_darwin.go
+++ b/llama/llama_darwin.go
@@ -1,0 +1,53 @@
+package llama
+
+import (
+	"errors"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	if err := initBackend(); err != nil {
+		log.Printf("WARNING: GPU could not be initialized correctly: %v", err)
+		log.Printf("WARNING: falling back to CPU")
+	}
+}
+
+func initBackend() error {
+	exec, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	exec, err = filepath.EvalSymlinks(exec)
+	if err != nil {
+		return err
+	}
+
+	metal := filepath.Join(filepath.Dir(exec), "ggml-metal.metal")
+	if _, err := os.Stat(metal); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		dst, err := os.Create(filepath.Join(filepath.Dir(exec), "ggml-metal.metal"))
+		if err != nil {
+			return err
+		}
+		defer dst.Close()
+
+		src, err := fs.Open("ggml-metal.metal")
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+
+		if _, err := io.Copy(dst, src); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
`go:embed ggml-metal.metal` and write it out to the right location on `init()` so llama.cpp can use it.

with this change, `ollama` is serveable using `go run . serve` or `go install . && ~/go/bin/ollama serve`

resolves #48