### PR TITLE
use max scan token size to hold large objects

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -24,6 +24,7 @@ func Parse(reader io.Reader) ([]Command, error) {
 	var command, modelCommand Command
 
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), bufio.MaxScanTokenSize)
 	scanner.Split(scanModelfile)
 	for scanner.Scan() {
 		line := scanner.Bytes()


### PR DESCRIPTION
The internal buffer used by scanner is too small to hold Meta's license so allocate the maximum size set in bufio. It can be potentially higher but it's not necessary right now