### PR TITLE
check server is running before running command

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -223,3 +223,10 @@ func (c *Client) Delete(ctx context.Context, req *DeleteRequest) error {
 	}
 	return nil
 }
+
+func (c *Client) Heartbeat(ctx context.Context) error {
+	if err := c.do(ctx, http.MethodGet, "/", nil, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/client.go
+++ b/api/client.go
@@ -225,7 +225,7 @@ func (c *Client) Delete(ctx context.Context, req *DeleteRequest) error {
 }
 
 func (c *Client) Heartbeat(ctx context.Context) error {
-	if err := c.do(ctx, http.MethodGet, "/", nil, nil); err != nil {
+	if err := c.do(ctx, http.MethodHead, "/", nil, nil); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -531,6 +531,9 @@ func startMacApp(client *api.Client) error {
 	if err != nil {
 		return err
 	}
+	if !strings.Contains(link, "Ollama.app") {
+		return fmt.Errorf("could not find ollama app")
+	}
 	path := strings.Split(link, "Ollama.app")
 	if err := exec.Command("/usr/bin/open", "-a", path[0]+"Ollama.app").Run(); err != nil {
 		return err
@@ -558,7 +561,7 @@ func checkServerHeartbeat(_ *cobra.Command, _ []string) error {
 		}
 		if runtime.GOOS == "darwin" {
 			if err := startMacApp(client); err != nil {
-				return fmt.Errorf("could not connect to ollama app server, run 'ollama serve' to start it")
+				return fmt.Errorf("could not connect to ollama app, is it running?")
 			}
 		} else {
 			return fmt.Errorf("could not connect to ollama server, run 'ollama serve' to start it")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -527,7 +527,11 @@ func RunServer(_ *cobra.Command, _ []string) error {
 }
 
 func startMacApp(client *api.Client) error {
-	link, err := os.Readlink("/usr/local/bin/ollama")
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	link, err := os.Readlink(exe)
 	if err != nil {
 		return err
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -319,6 +319,9 @@ func Serve(ln net.Listener) error {
 	r.GET("/", func(c *gin.Context) {
 		c.String(http.StatusOK, "Ollama is running")
 	})
+	r.HEAD("/", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
 
 	r.POST("/api/pull", PullModelHandler)
 	r.POST("/api/generate", GenerateHandler)


### PR DESCRIPTION
Check if the server is running rather than returning confusing "connection refused" errors. 

If the mac app is available start it, otherwise tell the user to run `ollama serve`.

resolves #47 