### PR TITLE
quantize f32, f16

### DIFF
--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -66,7 +66,7 @@ More examples are available in the [examples directory](../examples).
 
 ### FROM (Required)
 
-The FROM instruction defines the base model to use when creating a model.
+The `FROM` instruction defines the base model to use when creating a model.
 
 ```
 FROM <model name>:<tag>
@@ -88,6 +88,35 @@ FROM ./ollama-model.bin
 ```
 
 This bin file location should be specified as an absolute path or relative to the Modelfile location.
+
+### Build from unquantized bin file
+
+```
+FROM ./ollama-model-f16.bin AS Q4_0
+```
+
+This creates a model using the raw weights and converts it to 4-bit quantization. Other quantization levels are available depending on the original model type:
+
+- Q2\_K
+- Q3\_K
+- Q3\_K (alias for Q3\_K\_M)
+- Q3\_K\_S
+- Q3\_K\_M
+- Q3\_K\_L
+- Q4\_0
+- Q4\_1
+- Q4\_K (alias for Q4\_K\_M)
+- Q4\_K\_S
+- Q4\_K\_M
+- Q5\_0
+- Q5\_1
+- Q5\_K (alias for Q5\_K\_M)
+- Q5\_K\_S
+- Q5\_K\_M
+- Q6\_K
+- Q8\_0
+
+The model can also be converted into unquantized models F16 and F32.
 
 ### PARAMETER
 

--- a/llm/ggml.go
+++ b/llm/ggml.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
 
 type ModelFamily string
@@ -38,6 +39,45 @@ const (
 	FileTypeQ5_K
 	FileTypeQ6_K
 )
+
+func ParseFileType(family ModelFamily, s string) (FileType, error) {
+	switch family {
+	case ModelFamilyLlama:
+		return llamaParseFileType(s)
+	}
+
+	// if there's no family specific file type, parse as generic ggml file type
+	switch strings.ToLower(s) {
+	case "f32":
+		return FileTypeF32, nil
+	case "f16":
+		return FileTypeF16, nil
+	case "q4_0":
+		return FileTypeQ4_0, nil
+	case "q4_1":
+		return FileTypeQ4_1, nil
+	case "q4_1_f16":
+		return FileTypeQ4_1_F16, nil
+	case "q8_0":
+		return FileTypeQ8_0, nil
+	case "q5_0":
+		return FileTypeQ5_0, nil
+	case "q5_1":
+		return FileTypeQ5_1, nil
+	case "q2_k":
+		return FileTypeQ2_K, nil
+	case "q3_k":
+		return FileTypeQ3_K, nil
+	case "q4_k":
+		return FileTypeQ4_K, nil
+	case "q5_k":
+		return FileTypeQ5_K, nil
+	case "q6_k":
+		return FileTypeQ6_K, nil
+	}
+
+	return 0, fmt.Errorf("invalid file type: %s", s)
+}
 
 type GGML struct {
 	ModelFamily

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -37,6 +37,17 @@ func Parse(reader io.Reader) ([]Command, error) {
 		switch string(bytes.ToUpper(fields[0])) {
 		case "FROM":
 			command.Name = "model"
+			args := bytes.Split(fields[1], []byte(" "))
+
+			// FROM must be length 2, FROM <model>, or length 4, FROM <model> AS <quant>
+			if len(args) != 1 && len(args) != 3 {
+				return nil, fmt.Errorf("invalid FROM line: %s", line)
+			}
+
+			if len(args) == 3 && !bytes.Equal(bytes.ToUpper(args[1]), []byte("AS")) {
+				return nil, fmt.Errorf("invalid FROM line: %s", line)
+			}
+
 			command.Args = string(fields[1])
 			// copy command for validation
 			modelCommand = command


### PR DESCRIPTION
if the input model in a modelfile is a ggml f32 or f16 file type, and the `FROM` line contains the `AS` keyword, quantize the model to the specified level

Example Modelfile:
```
FROM /path/to/my/f32.bin AS Q4_0
```