### PR TITLE
Adds the ability to specify OLLAMA_HOST env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ Finally, run a model!
 ./ollama run llama2
 ```
 
+When using the Ollama command-line tool, you can define the `OLLAMA_HOST` environment variable to point to a different Ollama server, if not running on localhost:
+
+```
+export OLLAMA_HOST=https://my.ollama.server
+./ollama list  # executes API on OLLAMA_SERVER
+```
+
 ## REST API
 
 ### `POST /api/generate`

--- a/api/client.go
+++ b/api/client.go
@@ -9,13 +9,16 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 )
 
 type Client struct {
-	base    url.URL
-	HTTP    http.Client
+	base	url.URL
+	HTTP	http.Client
 	Headers http.Header
 }
+
+const DEFAULT_HOST string = "127.0.0.1:11434"
 
 func checkError(resp *http.Response, body []byte) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
@@ -33,8 +36,17 @@ func checkError(resp *http.Response, body []byte) error {
 	return apiError
 }
 
+func getDefaultHost() string {
+	host := os.Getenv("OLLAMA_HOST")
+	if host == "" {
+		host = DEFAULT_HOST
+	}
+
+	return host
+}
+
 func NewClient(hosts ...string) *Client {
-	host := "127.0.0.1:11434"
+	host := getDefaultHost()
 	if len(hosts) > 0 {
 		host = hosts[0]
 	}


### PR DESCRIPTION
For users who run the Ollama server on a host other than `localhost`, add the ability to specify OLLAMA_HOST as an environment variable.