### PR TITLE
add embed docs for modelfile

### DIFF
--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -12,6 +12,7 @@ A model file is the blueprint to create and share models with Ollama.
   - [FROM (Required)](#from-required)
     - [Build from llama2](#build-from-llama2)
     - [Build from a bin file](#build-from-a-bin-file)
+  - [EMBED](#embed)
   - [PARAMETER](#parameter)
     - [Valid Parameters and Values](#valid-parameters-and-values)
   - [TEMPLATE](#template)
@@ -87,6 +88,15 @@ FROM ./ollama-model.bin
 ```
 
 This bin file location should be specified as an absolute path or relative to the Modelfile location.
+
+### EMBED
+
+The EMBED instruction is used to add embeddings of files to a model. This is useful for adding custom data that the model can reference when generating an answer.
+
+```
+FROM <model name>:<tag>
+EMBED <file path>
+```
 
 ### PARAMETER
 

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -91,11 +91,12 @@ This bin file location should be specified as an absolute path or relative to th
 
 ### EMBED
 
-The EMBED instruction is used to add embeddings of files to a model. This is useful for adding custom data that the model can reference when generating an answer.
-
+The EMBED instruction is used to add embeddings of files to a model. This is useful for adding custom data that the model can reference when generating an answer. Note that currently only text files are supported, formatted with each line as one embedding.
 ```
 FROM <model name>:<tag>
-EMBED <file path>
+EMBED <file path>.txt
+EMBED <different file path>.txt
+EMBED <path to directory>/*.txt
 ```
 
 ### PARAMETER


### PR DESCRIPTION
I removed the embed instruction from our model documentation since its not in a release. Staging it here for a release.