### PR TITLE
Token auth

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -87,6 +87,10 @@ type ListResponseModel struct {
 	Size       int       `json:"size"`
 }
 
+type TokenResponse struct {
+	Token string `json:"token"`
+}
+
 type GenerateResponse struct {
 	Model     string    `json:"model"`
 	CreatedAt time.Time `json:"created_at"`

--- a/server/auth.go
+++ b/server/auth.go
@@ -20,16 +20,25 @@ import (
 	"github.com/jmorganca/ollama/api"
 )
 
+type AuthRedirect struct {
+	Realm   string
+	Service string
+	Scope   string
+}
+
 type SignatureData struct {
 	Method string
 	Path   string
 	Data   []byte
 }
 
-func getAuthToken(mp ModelPath, regOpts *RegistryOptions) (string, error) {
-	//url := fmt.Sprintf("%s/token", mp.Registry)
-	url := fmt.Sprintf("localhost/token?service=%s&scope=repository:%s:pull,push", mp.Registry, mp.GetNamespaceRepository())
-	//url := "localhost/token"
+func (r AuthRedirect) URL() string {
+	return fmt.Sprintf("%s?service=%s&scope=%s", r.Realm, r.Service, r.Scope)
+}
+
+func getAuthToken(redirData AuthRedirect, regOpts *RegistryOptions) (string, error) {
+	url := redirData.URL()
+
 	fmt.Printf("url = '%s'", url)
 
 	home, err := os.UserHomeDir()

--- a/server/auth.go
+++ b/server/auth.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/jmorganca/ollama/api"
+)
+
+type SignatureData struct {
+	Method string
+	Path   string
+	Data   []byte
+}
+
+func getAuthToken(mp ModelPath, regOpts *RegistryOptions) (string, error) {
+	//url := fmt.Sprintf("%s/token", mp.Registry)
+	url := fmt.Sprintf("localhost/token?service=%s&scope=repository:%s:pull,push", mp.Registry, mp.GetNamespaceRepository())
+	//url := "localhost/token"
+	fmt.Printf("url = '%s'", url)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	keyPath := path.Join(home, ".ollama/id_ed25519")
+
+	rawKey, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		log.Printf("Failed to load private key: %v", err)
+		return "", err
+	}
+
+	s := SignatureData{
+		Method: "GET",
+		Path:   url,
+		Data:   nil,
+	}
+
+	if !strings.HasPrefix(s.Path, "http") {
+		if regOpts.Insecure {
+			s.Path = "http://" + url
+		} else {
+			s.Path = "https://" + url
+		}
+	}
+
+	sig, err := s.Sign(rawKey)
+	if err != nil {
+		return "", err
+	}
+
+	log.Printf("sig = %s", sig)
+
+	headers := map[string]string{
+		"Authorization": sig,
+	}
+
+	resp, err := makeRequest("GET", url, headers, nil, regOpts)
+	if err != nil {
+		log.Printf("couldn't get token: %q", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for success: For a successful upload, the Docker registry will respond with a 201 Created
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("on pull registry responded with code %d: %s", resp.StatusCode, body)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var tok api.TokenResponse
+	if err := json.Unmarshal(respBody, &tok); err != nil {
+		return "", err
+	}
+
+	return tok.Token, nil
+}
+
+func (s SignatureData) Bytes() []byte {
+	// contentHash = base64(hex(sha256(s.Data)))
+	hash := sha256.Sum256(s.Data)
+	hashHex := make([]byte, hex.EncodedLen(len(hash)))
+	hex.Encode(hashHex, hash[:])
+	contentHash := base64.StdEncoding.EncodeToString(hashHex)
+	log.Printf("data = %v hash = %v hashHex = %v contentHash = %v", s.Data, hash, string(hashHex), contentHash)
+
+	log.Printf("string = '%s'", strings.Join([]string{s.Method, s.Path, contentHash}, ","))
+	// bytesToSign e.g.: "GET,http://localhost,OTdkZjM1O...
+	bytesToSign := []byte(strings.Join([]string{s.Method, s.Path, contentHash}, ","))
+
+	return bytesToSign
+}
+
+// SignData takes a SignatureData object and signs it with a raw private key
+func (s SignatureData) Sign(rawKey []byte) (string, error) {
+	privateKey, err := ssh.ParseRawPrivateKey(rawKey)
+	if err != nil {
+		return "", err
+	}
+
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		return "", err
+	}
+
+	// get the pubkey, but remove the type
+	pubKey := ssh.MarshalAuthorizedKey(signer.PublicKey())
+	parts := bytes.Split(pubKey, []byte(" "))
+	if len(parts) < 2 {
+		return "", fmt.Errorf("malformed private key")
+	}
+
+	signedData, err := signer.Sign(nil, s.Bytes())
+	if err != nil {
+		return "", err
+	}
+
+	// signature is <pubkey>:<signature>
+	sig := fmt.Sprintf("%s:%s", bytes.TrimSpace(parts[1]), base64.StdEncoding.EncodeToString(signedData.Blob))
+	return sig, nil
+}

--- a/server/images.go
+++ b/server/images.go
@@ -962,6 +962,13 @@ func PullModel(ctx context.Context, name string, regOpts *RegistryOptions, fn fu
 }
 
 func pullModelManifest(mp ModelPath, regOpts *RegistryOptions) (*ManifestV2, error) {
+	token, err := getAuthToken(mp, regOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("tok = %s", token)
+
 	url := fmt.Sprintf("%s/v2/%s/manifests/%s", mp.Registry, mp.GetNamespaceRepository(), mp.Tag)
 	headers := map[string]string{
 		"Accept": "application/vnd.docker.distribution.manifest.v2+json",


### PR DESCRIPTION
This change implements token authorization for the ollama server.

The basic steps for using auth are:
  1. make an authenticated call to the registry; if the registry returns a 401 w/ the Www-Authenticate header, then
  2. look for an SSH ed25519 key pair called `~/.ollama/id_ed25519`
  3. make a call to the token endpoint from the Www-Authenticate header w/ the signed Authorization header (this will be in the form `Authorization: <pub key>:<signature>`). The other params are given in the original 401 Www-Authenticate header which will include the realm and the scope
  4. the token endpoint will issue a new signed JWT for the source specified with the correct scope
  5. the request is made again, this time filling in the header as `Authorization: Bearer <jwt>`
  6. success (the model can be pushed or pulled)


