### PR TITLE
RFC: optional generate header to not stream response

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -182,6 +182,23 @@ func GenerateHandler(c *gin.Context) {
 		}
 	}()
 
+	if c.GetHeader("X-Streamed") == "false" {
+		var response api.GenerateResponse
+		generated := ""
+		for resp := range ch {
+			if r, ok := resp.(api.GenerateResponse); ok {
+				generated += r.Response
+				response = r
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected generate response type"})
+				return
+			}
+		}
+		response.Response = generated
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
 	streamResponse(c, ch)
 }
 


### PR DESCRIPTION
Add an optional request header to the generate endpoint that returns the full response in one JSON body, rather than streaming:
```
curl -X POST -H "Content-Type: application/json" -H "X-Streamed: false" -d '{
    "model": "llama2",
    "prompt": "why is the sky blue?"
}' 'localhost:11434/api/generate'
```

The issue suggests setting the `Content-Type` header to `application/json` to indicate the result should not be streamed, but thats not quite right since the content-type indicates the type of content in the request, rather than the response. 

We also can't use the `Accept: application/json`, this indicates the response that is expected, but clients would also use `Accept: application/json` in the case of a streaming response, because the returned objects will be json.

resolves #281
