### PR TITLE
Strip protocol from model path

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -115,7 +115,7 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	_, err = os.Stat(fp)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		if err := pull(args[0], false); err != nil {
+		if err := pull(args[0], insecure); err != nil {
 			var apiStatusError api.StatusError
 			if !errors.As(err, &apiStatusError) {
 				return err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -97,7 +97,16 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 }
 
 func RunHandler(cmd *cobra.Command, args []string) error {
-	mp := server.ParseModelPath(args[0])
+	insecure, err := cmd.Flags().GetBool("insecure")
+	if err != nil {
+		return err
+	}
+
+	mp, err := server.ParseModelPath(args[0], insecure)
+	if err != nil {
+		return err
+	}
+
 	fp, err := mp.GetManifestPath(false)
 	if err != nil {
 		return err
@@ -506,7 +515,11 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 		case strings.HasPrefix(line, "/show"):
 			args := strings.Fields(line)
 			if len(args) > 1 {
-				mp := server.ParseModelPath(model)
+				mp, err := server.ParseModelPath(model, false)
+				if err != nil {
+					return err
+				}
+
 				manifest, err := server.GetManifest(mp)
 				if err != nil {
 					fmt.Println("error: couldn't get a manifest for this model")
@@ -569,7 +582,7 @@ func generateBatch(cmd *cobra.Command, model string) error {
 }
 
 func RunServer(cmd *cobra.Command, _ []string) error {
-	var host, port = "127.0.0.1", "11434"
+	host, port := "127.0.0.1", "11434"
 
 	parts := strings.Split(os.Getenv("OLLAMA_HOST"), ":")
 	if ip := net.ParseIP(parts[0]); ip != nil {
@@ -630,7 +643,7 @@ func initializeKeypair() error {
 			return fmt.Errorf("could not create directory %w", err)
 		}
 
-		err = os.WriteFile(privKeyPath, pem.EncodeToMemory(privKeyBytes), 0600)
+		err = os.WriteFile(privKeyPath, pem.EncodeToMemory(privKeyBytes), 0o600)
 		if err != nil {
 			return err
 		}
@@ -642,7 +655,7 @@ func initializeKeypair() error {
 
 		pubKeyData := ssh.MarshalAuthorizedKey(sshPrivateKey.PublicKey())
 
-		err = os.WriteFile(pubKeyPath, pubKeyData, 0644)
+		err = os.WriteFile(pubKeyPath, pubKeyData, 0o644)
 		if err != nil {
 			return err
 		}
@@ -737,6 +750,7 @@ func NewCLI() *cobra.Command {
 	}
 
 	runCmd.Flags().Bool("verbose", false, "Show timings for response")
+	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
 
 	serveCmd := &cobra.Command{
 		Use:     "serve",

--- a/server/images.go
+++ b/server/images.go
@@ -153,7 +153,10 @@ func GetManifest(mp ModelPath) (*ManifestV2, error) {
 }
 
 func GetModel(name string) (*Model, error) {
-	mp := ParseModelPath(name)
+	mp, err := ParseModelPath(name, false)
+	if err != nil {
+		return nil, err
+	}
 
 	manifest, err := GetManifest(mp)
 	if err != nil {
@@ -272,7 +275,12 @@ func CreateModel(ctx context.Context, name string, path string, fn func(resp api
 		case "model":
 			fn(api.ProgressResponse{Status: "looking for model"})
 			embed.model = c.Args
-			mp := ParseModelPath(c.Args)
+
+			mp, err := ParseModelPath(c.Args, false)
+			if err != nil {
+				return err
+			}
+
 			mf, err := GetManifest(mp)
 			if err != nil {
 				modelFile, err := filenameWithPath(path, c.Args)
@@ -286,7 +294,7 @@ func CreateModel(ctx context.Context, name string, path string, fn func(resp api
 						if err := PullModel(ctx, c.Args, &RegistryOptions{}, fn); err != nil {
 							return err
 						}
-						mf, err = GetManifest(ParseModelPath(c.Args))
+						mf, err = GetManifest(mp)
 						if err != nil {
 							return fmt.Errorf("failed to open file after pull: %v", err)
 						}
@@ -654,7 +662,10 @@ func SaveLayers(layers []*LayerReader, fn func(resp api.ProgressResponse), force
 }
 
 func CreateManifest(name string, cfg *LayerReader, layers []*Layer) error {
-	mp := ParseModelPath(name)
+	mp, err := ParseModelPath(name, false)
+	if err != nil {
+		return err
+	}
 
 	manifest := ManifestV2{
 		SchemaVersion: 2,
@@ -786,11 +797,22 @@ func CreateLayer(f io.ReadSeeker) (*LayerReader, error) {
 }
 
 func CopyModel(src, dest string) error {
-	srcPath, err := ParseModelPath(src).GetManifestPath(false)
+	srcModelPath, err := ParseModelPath(src, false)
 	if err != nil {
 		return err
 	}
-	destPath, err := ParseModelPath(dest).GetManifestPath(true)
+
+	srcPath, err := srcModelPath.GetManifestPath(false)
+	if err != nil {
+		return err
+	}
+
+	destModelPath, err := ParseModelPath(dest, false)
+	if err != nil {
+		return err
+	}
+
+	destPath, err := destModelPath.GetManifestPath(true)
 	if err != nil {
 		return err
 	}
@@ -812,7 +834,10 @@ func CopyModel(src, dest string) error {
 }
 
 func DeleteModel(name string) error {
-	mp := ParseModelPath(name)
+	mp, err := ParseModelPath(name, false)
+	if err != nil {
+		return err
+	}
 
 	manifest, err := GetManifest(mp)
 	if err != nil {
@@ -839,7 +864,10 @@ func DeleteModel(name string) error {
 				return nil
 			}
 			tag := path[:slashIndex] + ":" + path[slashIndex+1:]
-			fmp := ParseModelPath(tag)
+			fmp, err := ParseModelPath(tag, false)
+			if err != nil {
+				return err
+			}
 
 			// skip the manifest we're trying to delete
 			if mp.GetFullTagname() == fmp.GetFullTagname() {
@@ -892,7 +920,10 @@ func DeleteModel(name string) error {
 }
 
 func PushModel(ctx context.Context, name string, regOpts *RegistryOptions, fn func(api.ProgressResponse)) error {
-	mp := ParseModelPath(name)
+	mp, err := ParseModelPath(name, regOpts.Insecure)
+	if err != nil {
+		return err
+	}
 
 	fn(api.ProgressResponse{Status: "retrieving manifest"})
 
@@ -975,7 +1006,10 @@ func PushModel(ctx context.Context, name string, regOpts *RegistryOptions, fn fu
 }
 
 func PullModel(ctx context.Context, name string, regOpts *RegistryOptions, fn func(api.ProgressResponse)) error {
-	mp := ParseModelPath(name)
+	mp, err := ParseModelPath(name, regOpts.Insecure)
+	if err != nil {
+		return err
+	}
 
 	fn(api.ProgressResponse{Status: "pulling manifest"})
 

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 )
@@ -23,33 +24,37 @@ const (
 	DefaultProtocolScheme = "https"
 )
 
+var protocolPattern = regexp.MustCompile(`^.*://`)
+
 func ParseModelPath(name string) ModelPath {
+	name = protocolPattern.ReplaceAllString(name, "")
+
 	slashParts := strings.Split(name, "/")
-	var registry, namespace, repository, tag string
+
+	registry := DefaultRegistry
+	namespace := DefaultNamespace
+	repository := ""
+	tag := DefaultTag
 
 	switch len(slashParts) {
 	case 3:
 		registry = slashParts[0]
 		namespace = slashParts[1]
-		repository = strings.Split(slashParts[2], ":")[0]
+		repository = slashParts[2]
 	case 2:
-		registry = DefaultRegistry
 		namespace = slashParts[0]
-		repository = strings.Split(slashParts[1], ":")[0]
+		repository = slashParts[1]
 	case 1:
-		registry = DefaultRegistry
-		namespace = DefaultNamespace
-		repository = strings.Split(slashParts[0], ":")[0]
+		repository = slashParts[0]
 	default:
 		fmt.Println("Invalid image format.")
 		return ModelPath{}
 	}
 
-	colonParts := strings.Split(slashParts[len(slashParts)-1], ":")
-	if len(colonParts) == 2 {
-		tag = colonParts[1]
-	} else {
-		tag = DefaultTag
+	repoParts := strings.Split(repository, ":")
+	if len(repoParts) == 2 {
+		repository = repoParts[0]
+		tag = repoParts[1]
 	}
 
 	return ModelPath{

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -27,43 +27,38 @@ const (
 var protocolPattern = regexp.MustCompile(`^.*://`)
 
 func ParseModelPath(name string) ModelPath {
+	mp := ModelPath{
+		ProtocolScheme: DefaultProtocolScheme,
+		Registry:       DefaultRegistry,
+		Namespace:      DefaultNamespace,
+		Repository:     "",
+		Tag:            DefaultTag,
+	}
+
 	name = protocolPattern.ReplaceAllString(name, "")
-
 	slashParts := strings.Split(name, "/")
-
-	registry := DefaultRegistry
-	namespace := DefaultNamespace
-	repository := ""
-	tag := DefaultTag
 
 	switch len(slashParts) {
 	case 3:
-		registry = slashParts[0]
-		namespace = slashParts[1]
-		repository = slashParts[2]
+		mp.Registry = slashParts[0]
+		mp.Namespace = slashParts[1]
+		mp.Repository = slashParts[2]
 	case 2:
-		namespace = slashParts[0]
-		repository = slashParts[1]
+		mp.Namespace = slashParts[0]
+		mp.Repository = slashParts[1]
 	case 1:
-		repository = slashParts[0]
+		mp.Repository = slashParts[0]
 	default:
 		fmt.Println("Invalid image format.")
 		return ModelPath{}
 	}
 
-	repoParts := strings.Split(repository, ":")
-	if len(repoParts) == 2 {
-		repository = repoParts[0]
-		tag = repoParts[1]
+	if repo, tag, didSplit := strings.Cut(mp.Repository, ":"); didSplit {
+		mp.Repository = repo
+		mp.Tag = tag
 	}
 
-	return ModelPath{
-		ProtocolScheme: DefaultProtocolScheme,
-		Registry:       registry,
-		Namespace:      namespace,
-		Repository:     repository,
-		Tag:            tag,
-	}
+	return mp
 }
 
 func (mp ModelPath) GetNamespaceRepository() string {

--- a/server/modelpath_test.go
+++ b/server/modelpath_test.go
@@ -1,0 +1,89 @@
+package server
+
+import "testing"
+
+func TestParseModelPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ModelPath
+	}{
+		{
+			"full path https",
+			"https://ollama.ai/ns/repo:tag",
+			ModelPath{
+				ProtocolScheme: DefaultProtocolScheme,
+				Registry:       "ollama.ai",
+				Namespace:      "ns",
+				Repository:     "repo",
+				Tag:            "tag",
+			},
+		},
+		{
+			"full path non-http",
+			"file://ollama.ai/ns/repo:tag",
+			ModelPath{
+				ProtocolScheme: DefaultProtocolScheme,
+				Registry:       "ollama.ai",
+				Namespace:      "ns",
+				Repository:     "repo",
+				Tag:            "tag",
+			},
+		},
+		{
+			"no protocol",
+			"ollama.ai/ns/repo:tag",
+			ModelPath{
+				ProtocolScheme: DefaultProtocolScheme,
+				Registry:       "ollama.ai",
+				Namespace:      "ns",
+				Repository:     "repo",
+				Tag:            "tag",
+			},
+		},
+		{
+			"no registry",
+			"ns/repo:tag",
+			ModelPath{
+				ProtocolScheme: DefaultProtocolScheme,
+				Registry:       DefaultRegistry,
+				Namespace:      "ns",
+				Repository:     "repo",
+				Tag:            "tag",
+			},
+		},
+		{
+			"no namespace",
+			"repo:tag",
+			ModelPath{
+				ProtocolScheme: DefaultProtocolScheme,
+				Registry:       DefaultRegistry,
+				Namespace:      DefaultNamespace,
+				Repository:     "repo",
+				Tag:            "tag",
+			},
+		},
+		{
+			"no tag",
+			"repo",
+			ModelPath{
+				ProtocolScheme: DefaultProtocolScheme,
+				Registry:       DefaultRegistry,
+				Namespace:      DefaultNamespace,
+				Repository:     "repo",
+				Tag:            DefaultTag,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseModelPath(tc.input)
+			want := tc.want
+
+			if got != want {
+				t.Errorf("got: %q want: %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/modelpath_test.go
+++ b/server/modelpath_test.go
@@ -10,10 +10,10 @@ func TestParseModelPath(t *testing.T) {
 	}{
 		{
 			"full path https",
-			"https://ollama.ai/ns/repo:tag",
+			"https://example.com/ns/repo:tag",
 			ModelPath{
 				ProtocolScheme: DefaultProtocolScheme,
-				Registry:       "ollama.ai",
+				Registry:       "example.com",
 				Namespace:      "ns",
 				Repository:     "repo",
 				Tag:            "tag",
@@ -21,10 +21,10 @@ func TestParseModelPath(t *testing.T) {
 		},
 		{
 			"full path non-http",
-			"file://ollama.ai/ns/repo:tag",
+			"file://example.com/ns/repo:tag",
 			ModelPath{
 				ProtocolScheme: DefaultProtocolScheme,
-				Registry:       "ollama.ai",
+				Registry:       "example.com",
 				Namespace:      "ns",
 				Repository:     "repo",
 				Tag:            "tag",
@@ -32,10 +32,10 @@ func TestParseModelPath(t *testing.T) {
 		},
 		{
 			"no protocol",
-			"ollama.ai/ns/repo:tag",
+			"example.com/ns/repo:tag",
 			ModelPath{
 				ProtocolScheme: DefaultProtocolScheme,
-				Registry:       "ollama.ai",
+				Registry:       "example.com",
 				Namespace:      "ns",
 				Repository:     "repo",
 				Tag:            "tag",
@@ -79,9 +79,7 @@ func TestParseModelPath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ParseModelPath(tc.input)
-			want := tc.want
-
-			if got != want {
+			if got != tc.want {
 				t.Errorf("got: %q want: %q", got, tc.want)
 			}
 		})

--- a/server/routes.go
+++ b/server/routes.go
@@ -357,7 +357,12 @@ func ListModelsHandler(c *gin.Context) {
 				return nil
 			}
 			tag := path[:slashIndex] + ":" + path[slashIndex+1:]
-			mp := ParseModelPath(tag)
+
+			mp, err := ParseModelPath(tag, false)
+			if err != nil {
+				return err
+			}
+
 			manifest, err := GetManifest(mp)
 			if err != nil {
 				log.Printf("skipping file: %s", fp)


### PR DESCRIPTION
Took a whack at fixing https://github.com/jmorganca/ollama/issues/371 and reorganized the switch logic slightly as well.

Wasn't sure if it was better to strip all protocols or just `https://`, so if you'd like the latter I can switch it to just a `strings.TrimPrefix`. Happy to back out the updated switch code as well, just figured I'd do it while I was in there.

Thanks for a great tool, loving it so far. Hope this is helpful.