### PR TITLE
Closes #371 

### DIFF
--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -24,7 +24,7 @@ const (
 )
 
 func ParseModelPath(name string) ModelPath {
-	slashParts := strings.Split(strings.trimPrefix(name, "https://"), "/")
+	slashParts := strings.Split(strings.TrimPrefix(name, "https://"), "/")
 	var registry, namespace, repository, tag string
 
 	switch len(slashParts) {

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -24,14 +24,10 @@ const (
 )
 
 func ParseModelPath(name string) ModelPath {
-	slashParts := strings.Split(name, "/")
+	slashParts := strings.Split(strings.trimPrefix(name, "https://"), "/")
 	var registry, namespace, repository, tag string
 
 	switch len(slashParts) {
-	case 5:
-		registry = slashParts[2]
-		namespace = slashParts[3]
-		repository = strings.Split(slashParts[4], ":")[0]
 	case 3:
 		registry = slashParts[0]
 		namespace = slashParts[1]

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -28,6 +28,10 @@ func ParseModelPath(name string) ModelPath {
 	var registry, namespace, repository, tag string
 
 	switch len(slashParts) {
+	case 5:
+		registry = slashParts[2]
+		namespace = slashParts[3]
+		repository = strings.Split(slashParts[4], ":")[0]
 	case 3:
 		registry = slashParts[0]
 		namespace = slashParts[1]


### PR DESCRIPTION
Hello,

ModelPath.ParseModelPath(name) now trims https:// from name if it is present. Keeping in the scope of the issue, no alternative protocols are accepted and a path with no protocol defaults to https as before. My first approach would've allowed garbage text in the protocol, but this lacks that side-effect.