### PR TITLE
add model IDs

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -96,6 +96,7 @@ type ListResponseModel struct {
 	Name       string    `json:"name"`
 	ModifiedAt time.Time `json:"modified_at"`
 	Size       int       `json:"size"`
+	Digest     string    `json:"digest"`
 }
 
 type TokenResponse struct {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -196,12 +196,12 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 
 	for _, m := range models.Models {
 		if len(args) == 0 || strings.HasPrefix(m.Name, args[0]) {
-			data = append(data, []string{m.Name, humanize.Bytes(uint64(m.Size)), format.HumanTime(m.ModifiedAt, "Never")})
+			data = append(data, []string{m.Name, m.Digest[:12], humanize.Bytes(uint64(m.Size)), format.HumanTime(m.ModifiedAt, "Never")})
 		}
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"NAME", "SIZE", "MODIFIED"})
+	table.SetHeader([]string{"NAME", "ID", "SIZE", "MODIFIED"})
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
@@ -527,7 +527,7 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 					return err
 				}
 
-				manifest, err := server.GetManifest(mp)
+				manifest, _, err := server.GetManifest(mp)
 				if err != nil {
 					fmt.Println("error: couldn't get a manifest for this model")
 					continue

--- a/server/routes.go
+++ b/server/routes.go
@@ -373,7 +373,7 @@ func ListModelsHandler(c *gin.Context) {
 			tag := path[:slashIndex] + ":" + path[slashIndex+1:]
 
 			mp := ParseModelPath(tag)
-			manifest, err := GetManifest(mp)
+			manifest, digest, err := GetManifest(mp)
 			if err != nil {
 				log.Printf("skipping file: %s", fp)
 				return nil
@@ -381,6 +381,7 @@ func ListModelsHandler(c *gin.Context) {
 			model := api.ListResponseModel{
 				Name:       mp.GetShortTagname(),
 				Size:       manifest.GetTotalSize(),
+				Digest:     digest,
 				ModifiedAt: fi.ModTime(),
 			}
 			models = append(models, model)


### PR DESCRIPTION
This change shows a portion (first 12 hex chars) of the sha256 sum of the manifest when running `ollama ls`. This makes it really easy at a glance to tell if two models are the same, and will make it easier in the future to match models inside of the ollama library.

It looks something like:
```
NAME                                    ID              SIZE    MODIFIED
codellama:34b-instruct                  901abb8f0f4b    19 GB   3 days ago
codellama:latest                        adf065e2ff94    3.8 GB  3 days ago
codeup:13b                              400f83199325    7.4 GB  2 weeks ago
llama-mario:latest                      d5793f033f5c    7.3 GB  4 weeks ago
llama2:13b                              156106c1e540    7.3 GB  4 weeks ago
llama2:latest                           5c1a4ea68dd0    3.8 GB  9 hours ago
llama2-uncensored:7b-chat-q6_K          26cf13ee4cfe    5.5 GB  8 days ago
llama2-uncensored:latest                5823fb1154c5    3.8 GB  4 weeks ago
nous-hermes:latest                      bfba379045c1    7.3 GB  6 weeks ago
```
