### PR TITLE
windows: fix filepath bugs

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -88,10 +88,10 @@ type PushRequest struct {
 }
 
 type ListResponse struct {
-	Models []ListResponseModel `json:"models"`
+	Models []ModelResponse `json:"models"`
 }
 
-type ListResponseModel struct {
+type ModelResponse struct {
 	Name       string    `json:"name"`
 	ModifiedAt time.Time `json:"modified_at"`
 	Size       int       `json:"size"`

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -46,7 +46,7 @@ func ParseModelPath(name string) ModelPath {
 		name = after
 	}
 
-	parts := strings.Split(name, "/")
+	parts := strings.Split(name, string(os.PathSeparator))
 	switch len(parts) {
 	case 3:
 		mp.Registry = parts[0]

--- a/server/routes.go
+++ b/server/routes.go
@@ -365,7 +365,7 @@ func DeleteModelHandler(c *gin.Context) {
 }
 
 func ListModelsHandler(c *gin.Context) {
-	var models []api.ListResponseModel
+	var models []api.ModelResponse
 	fp, err := GetManifestPath()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -398,7 +398,7 @@ func ListModelsHandler(c *gin.Context) {
 				log.Printf("skipping file: %s", fp)
 				return nil
 			}
-			model := api.ListResponseModel{
+			model := api.ModelResponse{
 				Name:       mp.GetShortTagname(),
 				Size:       manifest.GetTotalSize(),
 				Digest:     digest,


### PR DESCRIPTION
List and Delete has the same issue where the path was constructed using Linux/macOS path separators which does not work in Windows. This PR fixes and simplifies the code.

Fix `filenameWithPath` which also assumes a Linux/macOS path separator when looking for `~`.

Use `filenameWithPath` to resolve adapter filepath