### PR TITLE
do not HTML-escape prompt

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"log"
 	"net/http"
@@ -21,6 +20,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"text/template"
 
 	"github.com/jmorganca/ollama/api"
 	"github.com/jmorganca/ollama/llm"

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/jmorganca/ollama/api"
+)
+
+func TestModelPrompt(t *testing.T) {
+	var m Model
+	req := api.GenerateRequest{
+		Template: "a{{ .Prompt }}b",
+		Prompt:   "<h1>",
+	}
+	s, err := m.Prompt(req, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "a<h1>b"
+	if s != want {
+		t.Errorf("got %q, want %q", s, want)
+	}
+}


### PR DESCRIPTION
The `html/template` package automatically HTML-escapes interpolated strings in templates. This behavior is undesirable because it causes prompts like `<h1>hello` to be escaped to `&lt;h1&gt;hello` before being passed to the LLM.

The included test case passes, but before the code change, it failed:

```
--- FAIL: TestModelPrompt
    images_test.go:21: got "a&lt;h1&gt;b", want "a<h1>b"
```