### PR TITLE
create manifests directory

### DIFF
--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -114,7 +114,12 @@ func GetManifestPath() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(home, ".ollama", "models", "manifests"), nil
+	path := filepath.Join(home, ".ollama", "models", "manifests")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+
+	return path, nil
 }
 
 func GetBlobsPath(digest string) (string, error) {


### PR DESCRIPTION
`ollama list` on a brand new install will panic because the manifests directory doesn't exist