### PR TITLE
Add OLLAMA_HOME environment variable support.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jmorganca/ollama/format"
 	"github.com/jmorganca/ollama/progressbar"
 	"github.com/jmorganca/ollama/server"
+	"github.com/jmorganca/ollama/util"
 	"github.com/jmorganca/ollama/version"
 )
 
@@ -418,7 +419,7 @@ func generate(cmd *cobra.Command, model, prompt string) error {
 		if err := client.Generate(context.Background(), &request, fn); err != nil {
 			if strings.Contains(err.Error(), "failed to load model") {
 				// tell the user to check the server log, if it exists locally
-				home, nestedErr := os.UserHomeDir()
+				home, nestedErr := util.UserHomeDir()
 				if nestedErr != nil {
 					// return the original error
 					return err
@@ -456,7 +457,7 @@ func generate(cmd *cobra.Command, model, prompt string) error {
 }
 
 func generateInteractive(cmd *cobra.Command, model string) error {
-	home, err := os.UserHomeDir()
+	home, err := util.UserHomeDir()
 	if err != nil {
 		return err
 	}
@@ -676,7 +677,7 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 }
 
 func initializeKeypair() error {
-	home, err := os.UserHomeDir()
+	home, err := util.UserHomeDir()
 	if err != nil {
 		return err
 	}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,4 +14,10 @@ OLLAMA_ORIGINS=http://192.168.1.1:*,https://example.com ollama serve
 
 ## Where are models stored?
 
-Raw model data is stored under `~/.ollama/models`.
+Raw model data is stored under `~/.ollama/models`. 
+
+This can be customized from the default user home directory setting the `OLLAMA_HOME` environment variable when running the server. 
+
+```
+OLLAMA_HOME=~/my/custom/path/ ollama serve
+```

--- a/server/auth.go
+++ b/server/auth.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/jmorganca/ollama/api"
+	"github.com/jmorganca/ollama/util"
 )
 
 type AuthRedirect struct {
@@ -77,7 +78,7 @@ func getAuthToken(ctx context.Context, redirData AuthRedirect, regOpts *Registry
 		return "", err
 	}
 
-	home, err := os.UserHomeDir()
+	home, err := util.UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/server/images.go
+++ b/server/images.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jmorganca/ollama/api"
 	"github.com/jmorganca/ollama/llm"
 	"github.com/jmorganca/ollama/parser"
+	"github.com/jmorganca/ollama/util"
 	"github.com/jmorganca/ollama/vector"
 	"github.com/jmorganca/ollama/version"
 )
@@ -251,7 +252,7 @@ func filenameWithPath(path, f string) (string, error) {
 	// if filePath starts with ~/, replace it with the user's home directory.
 	if strings.HasPrefix(f, fmt.Sprintf("~%s", string(os.PathSeparator))) {
 		parts := strings.Split(f, string(os.PathSeparator))
-		home, err := os.UserHomeDir()
+		home, err := util.UserHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("failed to open file: %v", err)
 		}

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/jmorganca/ollama/util"
 )
 
 type ModelPath struct {
@@ -86,7 +88,7 @@ func (mp ModelPath) GetShortTagname() string {
 }
 
 func (mp ModelPath) GetManifestPath(createDir bool) (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := util.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
@@ -109,7 +111,7 @@ func (mp ModelPath) BaseURL() *url.URL {
 }
 
 func GetManifestPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := util.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +125,7 @@ func GetManifestPath() (string, error) {
 }
 
 func GetBlobsPath(digest string) (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := util.UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,22 @@
+package util
+
+import "os"
+
+// UserHomeDir returns the path to the user's home directory.
+//
+// It first checks if the "OLLAMA_HOME" environment variable is set and returns its value if so.
+// If the environment variable is not set, it uses the os.UserHomeDir() function to get the path.
+// The function returns the path as a string and an error if there was any issue getting the path.
+func UserHomeDir() (string, error) {
+	envHomePath := os.Getenv("OLLAMA_HOME")
+	if envHomePath != "" {
+		return envHomePath, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return home, nil
+}


### PR DESCRIPTION
## Problem

I'd like to run Ollama on my Linux server, but I have a small home directory disk. As a result, rather than changing the home directory to my mass storage pool, I propose adding the environment variable ```OLLAMA_HOME``` to set the top-level filepath for Ollama.

## Change

Switch out os.UserHomeDir with a wrapper in a new `util` package.

`util.UserHomeDir` attempts to fetch the OLLAMA_HOME environment variable, and falls back  otherwise.

Add documentation under `faq.md`. 


## Tests

Tested manually. I'd be happy to add automated tests for this if existing infrastructure exists.