### PR TITLE
add autoprune to remove unused layers

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -672,6 +672,12 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 		origins = strings.Split(o, ",")
 	}
 
+	if noprune := os.Getenv("OLLAMA_NOPRUNE"); noprune == "" {
+		if err := server.PruneLayers(false); err != nil {
+			return err
+		}
+	}
+
 	return server.Serve(ln, origins)
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -673,7 +673,7 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 	}
 
 	if noprune := os.Getenv("OLLAMA_NOPRUNE"); noprune == "" {
-		if err := server.PruneLayers(false); err != nil {
+		if err := server.PruneLayers(); err != nil {
 			return err
 		}
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -363,6 +363,7 @@ func DeleteModelHandler(c *gin.Context) {
 		}
 		return
 	}
+	c.JSON(http.StatusOK, nil)
 }
 
 func ShowModelHandler(c *gin.Context) {


### PR DESCRIPTION
This change will remove any unused layers for models. It runs at server startup, and will also clean up on `pull` or `create` commands which can orphan older layers.