### PR TITLE
set request.ContentLength

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -1442,6 +1442,15 @@ func makeRequest(ctx context.Context, method string, requestURL *url.URL, header
 
 	req.Header.Set("User-Agent", fmt.Sprintf("ollama/%s (%s %s) Go/%s", version.Version, runtime.GOARCH, runtime.GOOS, runtime.Version()))
 
+	if s := req.Header.Get("Content-Length"); s != "" {
+		contentLength, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		req.ContentLength = contentLength
+	}
+
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {


### PR DESCRIPTION
This informs the HTTP client the content length is known and disables chunked Transfer-Encoding