### PR TITLE
linux installer script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,17 +42,15 @@ check_sudo() {
 }
 
 install_cuda_drivers() {
-    local os_name os_version
+    local os_name
 
     if command -v lsb_release >/dev/null 2>&1; then
         os_name=$(lsb_release -is)
-        os_version=$(lsb_release -rs)
     else
         # If lsb_release is not available, fall back to /etc/os-release
         if [ -f "/etc/os-release" ]; then
             . /etc/os-release
             os_name=$ID
-            os_version=$VERSION_ID
         else
             echo "Unable to detect operating system."
             return 1
@@ -61,23 +59,6 @@ install_cuda_drivers() {
 
     # based on https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#package-manager-installation
     case $os_name in
-        RedHatEnterprise*)
-            version=$(lsb_release -rs | cut -d. -f1)
-            case $version in
-                7)
-                    echo "Red Hat Enterprise Linux 7 not implemented"
-                    ;;
-                8)
-                    echo "Red Hat Enterprise Linux 8 not implemented"
-                    ;;
-                9)
-                    echo "Red Hat Enterprise Linux 9 not implemented"
-                    ;;
-                *)
-                    echo "Unsupported or unknown Red Hat Enterprise Linux version, skipping GPU CUDA driver install: $version"
-                    ;;
-            esac
-            ;;
         CentOS)
             sudo yum install yum-utils
             sudo yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
@@ -88,27 +69,8 @@ install_cuda_drivers() {
             sudo dkms status | awk -F: '/added/ { print $1 }' | xargs -n1 sudo dkms install
             sudo modprobe nvidia
             ;;
-        Kylin)
-            echo "Kylin not implemented"
-            ;;
-        Fedora)
-            echo "Fedora not implemented"
-            ;;
-        SLES)
-            echo "SLES not implemented"
-            ;;
-        openSUSE*)
-            echo "OpenSUSE not implemented"
-            ;;
-        Microsoft)
-            # WSL
-            echo "WSL not implemented"
-            ;;
-        Ubuntu)
-            echo "Ubuntu not implemented"
-            ;;
-        Debian)
-            echo "Debian not implemented"
+        RedHatEnterprise*|Kylin|Fedora|SLES|openSUSE*|Microsoft|Ubuntu|Debian)
+            echo "NVIDIA CUDA drivers may not be installed, you can install them from: https://developer.nvidia.com/cuda-downloads"
             ;;
         *)
             echo "Unsupported or unknown distribution, skipping GPU CUDA driver install: $os_name"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,7 +55,7 @@ else
 fi
 
 ${SUDO_CMD} mkdir -p /usr/bin
-${SUDO_CMD} curl https://ollama.ai/download/latest/ollama-linux-$ARCH > /usr/bin/ollama
+${SUDO_CMD} curl -fsSL -o /usr/bin/ollama https://ollama.ai/download/latest/ollama-linux-$ARCH
 
 # Add ollama to start-up
 if command -v systemctl >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,7 +48,7 @@ else
     # Check for the presence of an NVIDIA GPU using lspci
     if lspci | grep -i "nvidia" >/dev/null 2>&1; then
         echo "Warning: NVIDIA GPU detected but NVIDIA-SMI is not available. Installing CUDA drivers..."
-        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${SUDO_CMD}sh -s -- --silent --driver
+        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${SUDO_CMD} sh -s -- --silent --driver
     else
         echo "No NVIDIA GPU detected. Skipping driver installation."
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,14 +60,14 @@ install_cuda_drivers() {
     # based on https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#package-manager-installation
     case $os_name in
         CentOS)
-            sudo yum install yum-utils
-            sudo yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-            sudo yum clean all
-            sudo yum -y install nvidia-driver-latest-dkms
-            sudo yum -y install cuda-driver
-            sudo yum install kernel-devel-$(uname -r) kernel-headers-$(uname -r)
-            sudo dkms status | awk -F: '/added/ { print $1 }' | xargs -n1 sudo dkms install
-            sudo modprobe nvidia
+            {$SUDO} yum install yum-utils
+            {$SUDO} yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+            {$SUDO} yum clean all
+            {$SUDO} yum -y install nvidia-driver-latest-dkms
+            {$SUDO} yum -y install cuda-driver
+            {$SUDO} yum install kernel-devel-$(uname -r) kernel-headers-$(uname -r)
+            {$SUDO} dkms status | awk -F: '/added/ { print $1 }' | xargs -n1 {$SUDO} dkms install
+            {$SUDO} modprobe nvidia
             ;;
         RedHatEnterprise*|Kylin|Fedora|SLES|openSUSE*|Microsoft|Ubuntu|Debian)
             echo "NVIDIA CUDA drivers may not be installed, you can install them from: https://developer.nvidia.com/cuda-downloads"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -133,9 +133,9 @@ main() {
     check_os
     determine_architecture
     check_sudo
-    check_install_cuda_drivers
     download_ollama
     configure_systemd
+    check_install_cuda_drivers
     echo "Installation complete. You can now run 'ollama' from the command line."
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,6 +99,8 @@ download_ollama() {
 
 configure_systemd() {
     if command -v systemctl >/dev/null 2>&1; then
+        $SUDO_CMD useradd -r -s /bin/false -m -d /home/ollama ollama 2>/dev/null 
+
         echo "Creating systemd service file for ollama..."
         cat <<EOF | $SUDO_CMD tee /etc/systemd/system/ollama.service >/dev/null
 [Unit]
@@ -107,9 +109,11 @@ After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/ollama serve
+User=ollama
+Group=ollama
 Restart=always
 RestartSec=3
-Environment="HOME=$HOME"
+Environment="HOME=/home/ollama"
 
 [Install]
 WantedBy=default.target
@@ -121,8 +125,7 @@ EOF
             $SUDO_CMD systemctl restart ollama
         fi
     else
-        echo "Installation complete. Run 'ollama serve' from the command line to start the service. Use 'ollama run' to query a model."
-        exit 0
+        echo "Run 'ollama serve' from the command line to start the service."
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,8 +4,7 @@
 
 set -eu
 
-os=$(uname -s)
-if [ "$os" != "Linux" ]; then
+if [ "$(uname -s)" != "Linux" ]; then
     echo "This script is intended to run on Linux only."
     exit 1
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,11 +27,13 @@ case $ARCH in
 esac
 
 SUDO_CMD=""
-
 if [ "$(id -u)" -ne 0 ]; then
     if command -v sudo >/dev/null 2>&1; then
         SUDO_CMD="sudo"
         echo "Downloading the ollama executable to the PATH, this will require sudo permissions."
+    else
+        echo "Error: sudo is not available. Please run as root or install sudo."
+        exit 1
     fi
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,7 +40,7 @@ if command -v nvidia-smi >/dev/null 2>&1; then
     CUDA_VERSION=$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")
     if [ -z "$CUDA_VERSION" ]; then
         echo "Warning: NVIDIA-SMI is available, but the CUDA version cannot be detected. Installing CUDA drivers..."
-        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${SUDO_CMD}sh -s -- --silent --driver
+        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${SUDO_CMD} sh -s -- --silent --driver
     else
         echo "Detected CUDA version $CUDA_VERSION"
     fi

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -77,6 +77,11 @@ RestartSec=3
 [Install]
 WantedBy=default.target
 EOF
+    # Reload systemd, enable and start the service
+    echo "Reloading systemd and enabling ollama service..."
+    sudo systemctl daemon-reload
+    sudo systemctl enable ollama
+    sudo systemctl start ollama
 else
     mv $TEMP/ollama /usr/local/bin/
     echo "Creating systemd service file for ollama..."
@@ -93,15 +98,7 @@ RestartSec=3
 [Install]
 WantedBy=default.target
 EOF
-fi
-
-# Reload systemd, enable and start the service
-echo "Reloading systemd and enabling ollama service..."
-if [ $IS_ROOT -eq 1 ]; then
-    sudo systemctl daemon-reload
-    sudo systemctl enable ollama
-    sudo systemctl start ollama
-else
+    echo "Reloading systemd and enabling ollama service..."
     systemctl daemon-reload
     systemctl enable ollama
     systemctl start ollama

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -26,7 +26,7 @@ case $ARCH in
         ;;
 esac
 
-if [ $IS_ROOT -eq 1 ]; then
+if [ "$(id -u)" -ne 0 ]; then
     sudo_cmd="sudo "
     echo "Downloading the ollama executable to the PATH, this will require sudo permissions."
 else
@@ -38,8 +38,7 @@ ${sudo_cmd}curl https://ollama.ai/download/latest/ollama-linux-$ARCH > /usr/bin/
 
 # Check if CUDA drivers are available
 if ! command -v nvidia-smi >/dev/null 2>&1; then
-    echo "Warning: NVIDIA CUDA drivers are not available on this system, install them to enable GPU support."
-    echo "https://developer.nvidia.com/cuda-downloads"
+    echo "Warning: NVIDIA CUDA drivers are not available on this system, install them to enable GPU support. For more information see: https://developer.nvidia.com/cuda-downloads"
 fi
 
 # Add ollama to start-up

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -64,7 +64,7 @@ if [ $IS_ROOT -eq 1 ]; then
     sudo mv $TEMP/ollama /usr/local/bin/
     # Create a systemd service file to auto-start ollama
     echo "Creating systemd service file for ollama..."
-    cat <<'EOF' | sudo tee /etc/systemd/system/ollama.service
+    cat <<EOF | sudo tee /etc/systemd/system/ollama.service
 [Unit]
 Description=Ollama Service
 After=network.target
@@ -73,6 +73,7 @@ After=network.target
 ExecStart=/usr/local/bin/ollama serve
 Restart=always
 RestartSec=3
+Environment="HOME=$HOME"
 
 [Install]
 WantedBy=default.target
@@ -85,7 +86,7 @@ EOF
 else
     mv $TEMP/ollama /usr/local/bin/
     echo "Creating systemd service file for ollama..."
-    cat <<'EOF' | tee /etc/systemd/system/ollama.service
+    cat <<EOF | tee /etc/systemd/system/ollama.service
 [Unit]
 Description=Ollama Service
 After=network.target
@@ -94,6 +95,7 @@ After=network.target
 ExecStart=/usr/local/bin/ollama serve
 Restart=always
 RestartSec=3
+Environment="HOME=$HOME"
 
 [Install]
 WantedBy=default.target

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -95,8 +95,6 @@ WantedBy=default.target
 EOF
 fi
 
-
-
 # Reload systemd, enable and start the service
 echo "Reloading systemd and enabling ollama service..."
 if [ $IS_ROOT -eq 1 ]; then

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# This script detects the current operating system architecture and installs the appropriate version of Ollama
+
+set -eu
+
+# Check for jq, systemd, and systemctl dependencies
+for cmd in "jq" "systemd" "systemctl"; do
+    if ! command -v $cmd > /dev/null 2>&1; then
+        echo "Error: $cmd is not installed, and this script requires it. Please install $cmd and try again."
+        exit 1
+    fi
+done
+
+# Determine the system architecture
+ARCH=$(uname -m)
+
+# Map architecture to the possible suffixes/names supported
+case $ARCH in
+    x86_64)
+        ARCH_SUFFIX="amd64"
+        ;;
+    aarch64|arm64)
+        ARCH_SUFFIX="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+# Fetch the latest release information from GitHub API
+RELEASE_INFO=$(curl -s "https://api.github.com/repos/jmorganca/ollama/releases/latest")
+
+# Extract the tag name for the latest release
+TAG_NAME=$(echo "$RELEASE_INFO" | jq -r '.tag_name')
+
+# Extract the download URL for the tarball (.tar.gz) using jq
+TARBALL_URL=$(echo "$RELEASE_INFO" | jq -r --arg ARCH_SUFFIX "$ARCH_SUFFIX" '.assets[] | select(.name | endswith($ARCH_SUFFIX+".tar.gz")) | .browser_download_url')
+
+# Download the tarball
+if [ -z "$TARBALL_URL" ]; then
+    echo "Failed to fetch the latest release information."
+    exit 1
+fi
+
+# Create a temporary directory and clean it up when script exits
+TEMP=$(mktemp -d)
+cleanup() { rm -rf $TEMP; }
+trap cleanup 0
+
+echo "Downloading and unpacking from $TARBALL_URL..."
+curl -sSfL "$TARBALL_URL" | tar zx -C $TEMP
+echo "Download and unpack complete."
+
+# Check if the user is root
+IS_ROOT=0
+if [ "$(id -u)" -ne 0 ]; then
+    IS_ROOT=1
+fi
+
+# Conditionally show the sudo warning and use sudo for the move operation
+if [ $IS_ROOT -eq 1 ]; then
+    echo "Moving the ollama executable to the PATH, this will require sudo permissions."
+    sudo mv $TEMP/ollama /usr/local/bin/
+    # Create a systemd service file to auto-start ollama
+    echo "Creating systemd service file for ollama..."
+    cat <<'EOF' | sudo tee /etc/systemd/system/ollama.service
+[Unit]
+Description=Ollama Service
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/ollama serve
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target
+EOF
+else
+    mv $TEMP/ollama /usr/local/bin/
+    echo "Creating systemd service file for ollama..."
+    cat <<'EOF' | tee /etc/systemd/system/ollama.service
+[Unit]
+Description=Ollama Service
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/ollama serve
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target
+EOF
+fi
+
+
+
+# Reload systemd, enable and start the service
+echo "Reloading systemd and enabling ollama service..."
+if [ $IS_ROOT -eq 1 ]; then
+    sudo systemctl daemon-reload
+    sudo systemctl enable ollama
+    sudo systemctl start ollama
+else
+    systemctl daemon-reload
+    systemctl enable ollama
+    systemctl start ollama
+fi
+
+echo "Installation complete. You can now run 'ollama' from the command line."

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -64,7 +64,7 @@ Description=Ollama Service
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/ollama serve
+ExecStart=/usr/bin/ollama serve
 Restart=always
 RestartSec=3
 Environment="HOME=$HOME"
@@ -92,14 +92,14 @@ elif [ -d "/etc/init.d" ]; then
 
 case "$1" in
   start)
-    /usr/local/bin/ollama serve &
+    /usr/bin/ollama serve &
     ;;
   stop)
     killall ollama
     ;;
   restart)
     killall ollama
-    /usr/local/bin/ollama serve &
+    /usr/bin/ollama serve &
     ;;
   *)
     echo "Usage: /etc/init.d/ollama {start|stop|restart}"

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -34,26 +34,22 @@ else
 fi
 
 # Check if CUDA drivers are available
-if command -v gcc >/dev/null 2>&1; then
-    if command -v nvidia-smi >/dev/null 2>&1; then
-        CUDA_VERSION=$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")
-        if [ -z "$CUDA_VERSION" ]; then
-            echo "Warning: NVIDIA-SMI is available, but the CUDA version cannot be detected. Installing CUDA drivers..."
-            curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
-        else
-            echo "Detected CUDA version $CUDA_VERSION"
-        fi
+if command -v nvidia-smi >/dev/null 2>&1; then
+    CUDA_VERSION=$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")
+    if [ -z "$CUDA_VERSION" ]; then
+        echo "Warning: NVIDIA-SMI is available, but the CUDA version cannot be detected. Installing CUDA drivers..."
+        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
     else
-        # Check for the presence of an NVIDIA GPU using lspci
-        if lspci | grep -i "nvidia" >/dev/null 2>&1; then
-            echo "Warning: NVIDIA GPU detected but NVIDIA-SMI is not available. Installing CUDA drivers..."
-            curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
-        else
-            echo "No NVIDIA GPU detected. Skipping driver installation."
-        fi
+        echo "Detected CUDA version $CUDA_VERSION"
     fi
 else
-    echo "Warning: gcc is not installed. CUDA graphics driver requires gcc for installation. Ollama will run on CPU."
+    # Check for the presence of an NVIDIA GPU using lspci
+    if lspci | grep -i "nvidia" >/dev/null 2>&1; then
+        echo "Warning: NVIDIA GPU detected but NVIDIA-SMI is not available. Installing CUDA drivers..."
+        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
+    else
+        echo "No NVIDIA GPU detected. Skipping driver installation."
+    fi
 fi
 
 ${sudo_cmd}mkdir -p /usr/bin

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -34,22 +34,26 @@ else
 fi
 
 # Check if CUDA drivers are available
-if command -v nvidia-smi >/dev/null 2>&1; then
-    CUDA_VERSION=$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")
-    if [ -z "$CUDA_VERSION" ]; then
-        echo "Warning: NVIDIA-SMI is available, but the CUDA version cannot be detected. Installing CUDA drivers..."
-        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
+if command -v gcc >/dev/null 2>&1; then
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        CUDA_VERSION=$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")
+        if [ -z "$CUDA_VERSION" ]; then
+            echo "Warning: NVIDIA-SMI is available, but the CUDA version cannot be detected. Installing CUDA drivers..."
+            curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
+        else
+            echo "Detected CUDA version $CUDA_VERSION"
+        fi
     else
-        echo "Detected CUDA version $CUDA_VERSION"
+        # Check for the presence of an NVIDIA GPU using lspci
+        if lspci | grep -i "nvidia" >/dev/null 2>&1; then
+            echo "Warning: NVIDIA GPU detected but NVIDIA-SMI is not available. Installing CUDA drivers..."
+            curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
+        else
+            echo "No NVIDIA GPU detected. Skipping driver installation."
+        fi
     fi
 else
-    # Check for the presence of an NVIDIA GPU using lspci
-    if lspci | grep -i "nvidia" >/dev/null 2>&1; then
-        echo "Warning: NVIDIA GPU detected but NVIDIA-SMI is not available. Installing CUDA drivers..."
-        curl https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run | ${sudo_cmd}sh -s -- --silent --driver
-    else
-        echo "No NVIDIA GPU detected. Skipping driver installation."
-    fi
+    echo "Warning: gcc is not installed. CUDA graphics driver requires gcc for installation. Ollama will run on CPU."
 fi
 
 ${sudo_cmd}mkdir -p /usr/bin

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -82,7 +82,7 @@ EOF
     echo "Reloading systemd and enabling ollama service..."
     sudo systemctl daemon-reload
     sudo systemctl enable ollama
-    sudo systemctl start ollama
+    sudo systemctl restart ollama
 else
     mv $TEMP/ollama /usr/local/bin/
     echo "Creating systemd service file for ollama..."

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -64,7 +64,7 @@ if [ $IS_ROOT -eq 1 ]; then
     sudo mv $TEMP/ollama /usr/local/bin/
     # Create a systemd service file to auto-start ollama
     echo "Creating systemd service file for ollama..."
-    cat <<EOF | sudo tee /etc/systemd/system/ollama.service
+    cat <<EOF | sudo tee /etc/systemd/system/ollama.service >/dev/null
 [Unit]
 Description=Ollama Service
 After=network.target
@@ -86,7 +86,7 @@ EOF
 else
     mv $TEMP/ollama /usr/local/bin/
     echo "Creating systemd service file for ollama..."
-    cat <<EOF | tee /etc/systemd/system/ollama.service
+    cat <<EOF | tee /etc/systemd/system/ollama.service >/dev/null
 [Unit]
 Description=Ollama Service
 After=network.target

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -76,44 +76,8 @@ EOF
     ${sudo_cmd}systemctl daemon-reload
     ${sudo_cmd}systemctl enable ollama
     ${sudo_cmd}systemctl restart ollama
-elif [ -d "/etc/init.d" ]; then
-    # Create an init.d script
-    echo "Creating init.d script for ollama..."
-    cat <<'EOF' | ${sudo_cmd}tee /etc/init.d/ollama >/dev/null
-#!/bin/sh
-### BEGIN INIT INFO
-# Provides:          ollama
-# Required-Start:    $network $local_fs $remote_fs
-# Required-Stop:     $network $local_fs $remote_fs
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Description:       Ollama service
-### END INIT INFO
-
-case "$1" in
-  start)
-    /usr/bin/ollama serve &
-    ;;
-  stop)
-    killall ollama
-    ;;
-  restart)
-    killall ollama
-    /usr/bin/ollama serve &
-    ;;
-  *)
-    echo "Usage: /etc/init.d/ollama {start|stop|restart}"
-    exit 1
-    ;;
-esac
-
-exit 0
-EOF
-    ${sudo_cmd}chmod +x /etc/init.d/ollama
-    ${sudo_cmd}update-rc.d ollama defaults
-    ${sudo_cmd}service ollama start
 else
-    echo "Installation complete. Run 'ollama serve' from the command line to start the service."
+    echo "Installation complete. Run 'ollama serve' from the command line to start the service. Use 'ollama run' to query a model."
     exit 0
 fi
 


### PR DESCRIPTION
Add an install script to the website which downloads the appropriate linux package, unpackages it, adds it to the /usr/local/bin directory, and adds ollama as start-up service.

Before our next release we will:

- Do linux amd64 and aarch64 builds with CUDA enabled.
- Add them to the pre-release of the jmorgan/ollama repo with the names ollama-linux-arm64.tar.gz and ollama-linux-amd64.tar.gz
- This install script will automatically download the latest version of these files from github releases which are not pre-release.