### PR TITLE
Allow setting ollama home directory through environment var OLLAMA_HOME.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/jmorganca/ollama/api"
 	"github.com/jmorganca/ollama/format"
+	"github.com/jmorganca/ollama/paths"
 	"github.com/jmorganca/ollama/progressbar"
 	"github.com/jmorganca/ollama/server"
 	"github.com/jmorganca/ollama/version"
@@ -472,7 +473,7 @@ func generate(cmd *cobra.Command, model, prompt string) error {
 	if err := client.Generate(context.Background(), &request, fn); err != nil {
 		if strings.Contains(err.Error(), "failed to load model") {
 			// tell the user to check the server log, if it exists locally
-			home, nestedErr := os.UserHomeDir()
+			home, nestedErr := paths.OllamaHomeDir()
 			if nestedErr != nil {
 				// return the original error
 				return err
@@ -510,7 +511,7 @@ func generate(cmd *cobra.Command, model, prompt string) error {
 }
 
 func generateInteractive(cmd *cobra.Command, model string) error {
-	home, err := os.UserHomeDir()
+	home, err := paths.OllamaHomeDir()
 	if err != nil {
 		return err
 	}
@@ -731,7 +732,7 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 }
 
 func initializeKeypair() error {
-	home, err := os.UserHomeDir()
+	home, err := paths.OllamaHomeDir()
 	if err != nil {
 		return err
 	}

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -1,0 +1,16 @@
+package paths
+
+import (
+	"os"
+)
+
+const ollamaHomeEnvVar = "OLLAMA_HOME"
+
+func OllamaHomeDir() (string, error) {
+	ev := os.Getenv(ollamaHomeEnvVar)
+	if len(ev) > 0 {
+		return ev, nil
+	}
+
+	return os.UserHomeDir()
+}

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -1,0 +1,46 @@
+package paths
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOllamaHomeDirWithEnvVarSet(t *testing.T) {
+	err := os.Setenv(ollamaHomeEnvVar, "/haha/hihi")
+	if err != nil {
+		t.Fatalf("could not set env var %q: %s", ollamaHomeEnvVar, err)
+	}
+
+	got, err := OllamaHomeDir()
+	if err != nil {
+		t.Fatalf("error on OllamaHomeDir(): %s", err)
+	}
+
+	want := "/haha/hihi"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestOllamaHomeDirWithoutEnvVarSet(t *testing.T) {
+	// unset env var
+	err := os.Setenv(ollamaHomeEnvVar, "")
+	if err != nil {
+		t.Fatalf("could not unset %q: %s", ollamaHomeEnvVar, err)
+	}
+
+	userHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("error on UserHomeDir(): %s", err)
+	}
+
+	got, err := OllamaHomeDir()
+	if err != nil {
+		t.Fatalf("error on OllamaHomeDir(): %s", err)
+	}
+
+	want := userHomeDir
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/server/auth.go
+++ b/server/auth.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/jmorganca/ollama/api"
+	"github.com/jmorganca/ollama/paths"
 )
 
 type AuthRedirect struct {
@@ -77,7 +78,7 @@ func getAuthToken(ctx context.Context, redirData AuthRedirect) (string, error) {
 		return "", err
 	}
 
-	home, err := os.UserHomeDir()
+	home, err := paths.OllamaHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/server/images.go
+++ b/server/images.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jmorganca/ollama/api"
 	"github.com/jmorganca/ollama/llm"
 	"github.com/jmorganca/ollama/parser"
+	"github.com/jmorganca/ollama/paths"
 	"github.com/jmorganca/ollama/vector"
 	"github.com/jmorganca/ollama/version"
 )
@@ -251,7 +252,7 @@ func filenameWithPath(path, f string) (string, error) {
 	// if filePath starts with ~/, replace it with the user's home directory.
 	if strings.HasPrefix(f, fmt.Sprintf("~%s", string(os.PathSeparator))) {
 		parts := strings.Split(f, string(os.PathSeparator))
-		home, err := os.UserHomeDir()
+		home, err := paths.OllamaHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("failed to open file: %v", err)
 		}

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/jmorganca/ollama/paths"
 )
 
 type ModelPath struct {
@@ -86,7 +88,7 @@ func (mp ModelPath) GetShortTagname() string {
 }
 
 func (mp ModelPath) GetManifestPath(createDir bool) (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := paths.OllamaHomeDir()
 	if err != nil {
 		return "", err
 	}
@@ -109,7 +111,7 @@ func (mp ModelPath) BaseURL() *url.URL {
 }
 
 func GetManifestPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := paths.OllamaHomeDir()
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +125,7 @@ func GetManifestPath() (string, error) {
 }
 
 func GetBlobsPath(digest string) (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := paths.OllamaHomeDir()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
It would be great to be able to specify a different directory location than the default user-home directory.