### PR TITLE
Cmd changes

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,7 +36,8 @@ import (
 type Painter struct{}
 
 func (p Painter) Paint(line []rune, l int) []rune {
-	if len(line) == 0 {
+	termType := os.Getenv("TERM")
+	if termType == "xterm-256color" && len(line) == 0 {
 		prompt := "Send a message (/? for help)"
 		return []rune(fmt.Sprintf("\033[38;5;245m%s\033[%dD\033[0m", prompt, len(prompt)))
 	}
@@ -440,8 +441,10 @@ func generate(cmd *cobra.Command, model, prompt string) error {
 		return err
 	}
 
-	fmt.Println()
-	fmt.Println()
+	if prompt != "" {
+		fmt.Println()
+		fmt.Println()
+	}
 
 	if !latest.Done {
 		return errors.New("unexpected end of response")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -33,6 +33,16 @@ import (
 	"github.com/jmorganca/ollama/version"
 )
 
+type Painter struct{}
+
+func (p Painter) Paint(line []rune, l int) []rune {
+	if len(line) == 0 {
+		prompt := "Send a message (/? for help)"
+		return []rune(fmt.Sprintf("\033[38;5;245m%s\033[%dD\033[0m", prompt, len(prompt)))
+	}
+	return line
+}
+
 func CreateHandler(cmd *cobra.Command, args []string) error {
 	filename, _ := cmd.Flags().GetString("file")
 	filename, err := filepath.Abs(filename)
@@ -460,12 +470,9 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 	}
 
 	// load the model
-	fmt.Printf("Ollama %s\n", version.Version)
-	fmt.Printf("Loading %s\n", model)
 	if err := generate(cmd, model, ""); err != nil {
 		return err
 	}
-	fmt.Printf("Type /? for help\n")
 
 	completer := readline.NewPrefixCompleter(
 		readline.PcItem("/help"),
@@ -498,6 +505,7 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 	}
 
 	config := readline.Config{
+		Painter:      Painter{},
 		Prompt:       ">>> ",
 		HistoryFile:  filepath.Join(home, ".ollama", "history"),
 		AutoComplete: completer,

--- a/server/routes.go
+++ b/server/routes.go
@@ -218,8 +218,12 @@ func GenerateHandler(c *gin.Context) {
 			ch <- r
 		}
 
-		if err := loaded.llm.Predict(c.Request.Context(), req.Context, prompt, fn); err != nil {
-			ch <- gin.H{"error": err.Error()}
+		if req.Prompt == "" {
+			ch <- api.GenerateResponse{Model: req.Model, Done: true}
+		} else {
+			if err := loaded.llm.Predict(c.Request.Context(), req.Context, prompt, fn); err != nil {
+				ch <- gin.H{"error": err.Error()}
+			}
 		}
 	}()
 


### PR DESCRIPTION
This changes the API so that it can use `POST /api/generate` to pre-load a model if the prompt is empty. It also changes the REPL so that it can pre-load the model by making a call to generate automatically, and includes a change for using placeholder text.