### PR TITLE
add word wrapping for lines which are longer than the terminal width

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -610,7 +610,7 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 					fmt.Println("Set 'nowordwrap' mode.")
 				case "verbose":
 					cmd.Flags().Set("verbose", "true")
-					fmt.Println("Set 'versbose' mode.")
+					fmt.Println("Set 'verbose' mode.")
 				case "quiet":
 					cmd.Flags().Set("verbose", "false")
 					fmt.Println("Set 'quiet' mode.")

--- a/go.sum
+++ b/go.sum
@@ -120,7 +120,6 @@ golang.org/x/arch v0.3.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
 golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
 golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
 golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=


### PR DESCRIPTION
This change makes it so the REPL will properly wrap a line on a word boundary. The way it works is that it walks through each character of each token returned by the server, and then keeps a buffer of the last word. If the maximum boundary length is exceeded, it will backtrack using ANSI escape codes to the length of the current word buffer, erase to the end of the line, give a line feed, and then add the word fragment to the new line. This requires that the terminal allow ANSI graphics which should be OK for any modern terminal. If you run this headless, it will default to not wrapping any lines.

Right now I've set the width to 5 characters less than the terminal width, but we potentially make this a setting in the future.

This fixes issue #150 
