### PR TITLE
fix OLLAMA_HOST parsing for ip6

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -655,28 +655,19 @@ func generateBatch(cmd *cobra.Command, model string) error {
 }
 
 func RunServer(cmd *cobra.Command, _ []string) error {
-	host, port := "127.0.0.1", "11434"
-
-	parts := strings.Split(os.Getenv("OLLAMA_HOST"), ":")
-	if ip := net.ParseIP(parts[0]); ip != nil {
-		host = ip.String()
-	}
-
-	if len(parts) > 1 {
-		port = parts[1]
-	}
-
-	// deprecated: include port in OLLAMA_HOST
-	if p := os.Getenv("OLLAMA_PORT"); p != "" {
-		port = p
-	}
-
-	err := initializeKeypair()
+	host, port, err := net.SplitHostPort(os.Getenv("OLLAMA_HOST"))
 	if err != nil {
+		host, port = "127.0.0.1", "11434"
+		if ip := net.ParseIP(os.Getenv("OLLAMA_HOST")); ip != nil {
+			host = ip.String()
+		}
+	}
+
+	if err := initializeKeypair(); err != nil {
 		return err
 	}
 
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%s", host, port))
+	ln, err := net.Listen("tcp", net.JoinHostPort(host, port))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix the environment parsing for `OLLAMA_HOST` so it can recognize ipv6 addresses, e.g. ipv6 loopback `[::1]:11434`

Some examples:

Default

```
$ OLLAMA_HOST='' ollama serve
2023/09/20 17:55:23 routes.go:540: Listening on 127.0.0.1:11434
```

IPv6 loopback

```
$ OLLAMA_HOST='[::1]:11434' ollama serve
2023/09/20 17:58:08 routes.go:540: Listening on [::1]:11434
```

Random port (any IPv4 & IPv6 address)

```
$ OLLAMA_HOST=':0' ollama serve
2023/09/20 17:58:26 routes.go:540: Listening on [::]:63574
```

Only IPv4

```
$ OLLAMA_HOST='127.0.0.1:12345' ollama serve
2023/09/20 17:58:37 routes.go:540: Listening on 127.0.0.1:12345
```

Only IPv6

```
$ OLLAMA_HOST='[::1]:12345' ollama serve
2023/09/20 17:59:23 routes.go:540: Listening on [::1]:12345
```

Only setting the address

```
$ OLLAMA_HOST='0.0.0.0' ollama serve
2023/09/20 18:54:18 routes.go:540: Listening on [::]:11434
```

It also removes `OLLAMA_PORT`

Resolves #560 