### PR TITLE
Add support for GBNF grammar definitions

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -195,6 +195,7 @@ type Options struct {
 	Mirostat         int      `json:"mirostat,omitempty"`
 	MirostatTau      float32  `json:"mirostat_tau,omitempty"`
 	MirostatEta      float32  `json:"mirostat_eta,omitempty"`
+	Grammar          string   `json:"grammar,omitempty"`
 	PenalizeNewline  bool     `json:"penalize_newline,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
 

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -127,6 +127,7 @@ PARAMETER <parameter> <parametervalue>
 | tfs_z          | Tail free sampling is used to reduce the impact of less probable tokens from the output. A higher value (e.g., 2.0) will reduce the impact more, while a value of 1.0 disables this setting. (default: 1)                                               | float      | tfs_z 1              |
 | top_k          | Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative. (Default: 40)                                                                        | int        | top_k 40             |
 | top_p          | Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)                                                                 | float      | top_p 0.9            |
+| grammar        | The [GBNF](https://github.com/ggerganov/llama.cpp/tree/master/grammars) grammar used to constrain the model output. | string | grammar "root ::= [0-9]+" |
 
 ### TEMPLATE
 

--- a/examples/json/Modelfile
+++ b/examples/json/Modelfile
@@ -1,0 +1,33 @@
+FROM codellama:13b-instruct-q5_K_M
+
+# JSON grammar provided by llama.cpp
+# MIT License
+# Copyright (c) 2023 Georgi Gerganov
+
+PARAMETER grammar """
+root   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+
+object ::=
+  "{" ws (
+            string ":" ws value
+    ("," ws string ":" ws value)*
+  )? "}" ws
+
+array  ::=
+  "[" ws (
+            value
+    ("," ws value)*
+  )? "]" ws
+
+string ::=
+  "\"" (
+    [^"\\] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+  )* "\"" ws
+
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= ([ \t\n] ws)?
+"""

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -428,6 +428,7 @@ type PredictRequest struct {
 	Mirostat         int             `json:"mirostat,omitempty"`
 	MirostatTau      float32         `json:"mirostat_tau,omitempty"`
 	MirostatEta      float32         `json:"mirostat_eta,omitempty"`
+	Grammar          string          `json:"grammar,omitempty"`
 	PenalizeNl       bool            `json:"penalize_nl,omitempty"`
 	NKeep            int             `json:"n_keep,omitempty"`
 	Seed             int             `json:"seed,omitempty"`
@@ -466,6 +467,7 @@ func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string,
 		Mirostat:         llm.Mirostat,
 		MirostatTau:      llm.MirostatTau,
 		MirostatEta:      llm.MirostatEta,
+		Grammar:          llm.Grammar,
 		PenalizeNl:       llm.PenalizeNewline,
 		Stop:             llm.Stop,
 	}


### PR DESCRIPTION
This PR exposes the llama.cpp `grammar` parameter in the generate API.

It allows the user to provide a [GBNF grammar](https://github.com/ggerganov/llama.cpp/tree/master/grammars) to constrain the output of an LLM.

This can be used to, for example, reliably generate structured data like JSON:

```
>>> Generate a list of 5 random mock users that contain a firstname, lastname, birthday, created_at and email field. The created_at field should be RFC3339 and lie in the range of 2000 to 2020. Emails should use multiple subdomains under the example.com domain. The result should be in a JSON object with a users key.
{
    "users": [
      {
        "firstname": "Emma",
        "lastname": "Brown",
        "birthday": "1993-08-12T00:00:00Z",
        "created_at": "2017-04-15T13:00:00Z",
        "email": "emma.brown@example.co.uk"
      },
      {
        "firstname": "Olivia",
        "lastname": "Jones",
        "birthday": "1996-03-25T00:00:00Z",
        "created_at": "2018-02-17T14:00:00Z",
        "email": "olivia.jones@example.edu"
      },
      {
        "firstname": "Ava",
        "lastname": "Smith",
        "birthday": "1997-08-24T00:00:00Z",
        "created_at": "2019-05-12T15:00:00Z",
        "email": "ava.smith@example.net"
      },
      {
        "firstname": "Sophia",
        "lastname": "Johnson",
        "birthday": "1998-04-26T00:00:00Z",
        "created_at": "2020-03-07T16:00:00Z",
        "email": "sophia.johnson@example.org"
      },
      {
        "firstname": "Mia",
        "lastname": "Williams",
        "birthday": "1999-07-23T00:00:00Z",
        "created_at": "2020-12-08T17:00:00Z",
        "email": "mia.williams@example.com"
      }
    ]
  }

>>> Create a JSON object that contains the latest birthday and the earliest created_at date, omit the time.
{
"latest_birthday": "1999-07-23",
"earliest_created_at": "2000-01-01"
}
```
*Generated with the examples/json Modelfile, first attempt, not cherry-picked*

**A note for potential users**
The generated documents are first try valid JSON, without extra tuning.
But note how the LLM used different TLD's, not subdomains. The `earliest_created_at` is also not as intended, the instruction is ambiguous.
This only ensures that the grammar is followed, the semantics might still be wrong.