### PR TITLE
fix HEAD request

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -543,12 +543,11 @@ func Serve(ln net.Listener, allowOrigins []string) error {
 		},
 	)
 
-	r.GET("/", func(c *gin.Context) {
-		c.String(http.StatusOK, "Ollama is running")
-	})
-	r.HEAD("/", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		r.Handle(method, "/", func(c *gin.Context) {
+			c.String(http.StatusOK, "Ollama is running")
+		})
+	}
 
 	r.POST("/api/pull", PullModelHandler)
 	r.POST("/api/generate", GenerateHandler)

--- a/server/routes.go
+++ b/server/routes.go
@@ -543,21 +543,22 @@ func Serve(ln net.Listener, allowOrigins []string) error {
 		},
 	)
 
-	for _, method := range []string{http.MethodGet, http.MethodHead} {
-		r.Handle(method, "/", func(c *gin.Context) {
-			c.String(http.StatusOK, "Ollama is running")
-		})
-	}
-
 	r.POST("/api/pull", PullModelHandler)
 	r.POST("/api/generate", GenerateHandler)
 	r.POST("/api/embeddings", EmbeddingHandler)
 	r.POST("/api/create", CreateModelHandler)
 	r.POST("/api/push", PushModelHandler)
 	r.POST("/api/copy", CopyModelHandler)
-	r.GET("/api/tags", ListModelsHandler)
 	r.DELETE("/api/delete", DeleteModelHandler)
 	r.POST("/api/show", ShowModelHandler)
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		r.Handle(method, "/", func(c *gin.Context) {
+			c.String(http.StatusOK, "Ollama is running")
+		})
+
+		r.Handle(method, "/api/tags", ListModelsHandler)
+	}
 
 	log.Printf("Listening on %s", ln.Addr())
 	s := &http.Server{


### PR DESCRIPTION
HEAD request should respond like their GET counterparts except without a response body.

The previous implementation didn't quite satisfy this since it doesn't attach a response body so the content length is zero while the GET request responded with `Ollama is running`, content length 17.

Despite having a response body, gin will omit it in the actual response:

```
$ http HEAD :11434/
HTTP/1.1 200 OK
Content-Length: 17
Content-Type: text/plain; charset=utf-8
Date: Thu, 21 Sep 2023 23:41:08 GMT




$ http GET :11434/
HTTP/1.1 200 OK
Content-Length: 17
Content-Type: text/plain; charset=utf-8
Date: Thu, 21 Sep 2023 23:41:11 GMT

Ollama is running



```