### PR TITLE
fix ipv6 parse ip

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -650,7 +650,7 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 	host, port, err := net.SplitHostPort(os.Getenv("OLLAMA_HOST"))
 	if err != nil {
 		host, port = "127.0.0.1", "11434"
-		if ip := net.ParseIP(os.Getenv("OLLAMA_HOST")); ip != nil {
+		if ip := net.ParseIP(strings.Trim(os.Getenv("OLLAMA_HOST"), "[]")); ip != nil {
 			host = ip.String()
 		}
 	}


### PR DESCRIPTION
`net.ParseIP` for IPv6 doesn't expect `[]` so trim it