### PR TITLE
update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,6 +117,11 @@ check_gpu() {
     esac
 }
 
+if check_gpu nvidia-smi; then
+    status "NVIDIA GPU installed."
+    exit 0
+fi
+
 if ! check_gpu lspci && ! check_gpu lshw; then
     warning "No NVIDIA GPU detected. Ollama will run in CPU-only mode."
     exit 0
@@ -228,3 +233,6 @@ if ! lsmod | grep -q nvidia; then
 
     $SUDO modprobe nvidia
 fi
+
+
+status "NVIDIA GPU installed."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,6 +82,7 @@ Group=ollama
 Restart=always
 RestartSec=3
 Environment="HOME=/usr/share/ollama"
+Environment="PATH=$PATH"
 
 [Install]
 WantedBy=default.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,7 +92,9 @@ EOF
             status "Enabling and starting ollama service..."
             $SUDO systemctl daemon-reload
             $SUDO systemctl enable ollama
-            $SUDO systemctl restart ollama
+
+            start_service() { $SUDO systemctl restart ollama; }
+            trap start_service EXIT
             ;;
     esac
 }


### PR DESCRIPTION
This prevents the service from restarting too early and not detecting GPU before drivers are installed.

Fix PATH for WSL user. WSL preinstalls CUDA toolkit but it's in a non-standard path (`/usr/lib/wsl/lib`). While this is set for a normal WSL user, it's not set for the ollama user. This change sets PATH of the ollama service to the PATH of the caller