### PR TITLE
do not unload nouveau driver

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,12 +227,12 @@ if ! lsmod | grep -q nvidia; then
     fi
 
     if lsmod | grep -q nouveau; then
-        status "Removing nouveau..."
-        $SUDO rmmod nouveau
+        status 'Reboot to complete NVIDIA CUDA driver install.'
+        exit 0
     fi
 
     $SUDO modprobe nvidia
 fi
 
 
-status "NVIDIA GPU installed."
+status "NVIDIA CUDA drivers installed."


### PR DESCRIPTION
unloading this driver on a desktop kills the display which is not optimal. instead, inform the user they need to reboot