### PR TITLE
do not reload model when only prompt template changes

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -69,7 +69,7 @@ func chooseRunners(workDir, runnerType string) []ModelRunner {
 		files, err := fs.Glob(llamaCppEmbed, path.Join(path.Dir(r.Path), "*"))
 		if err != nil {
 			// this is expected, ollama may be compiled without all runners packed in
-			log.Printf("%s runner not found: %v", r, err)
+			log.Printf("%s runner not found: %v", r.Path, err)
 			continue
 		}
 

--- a/server/images.go
+++ b/server/images.go
@@ -36,13 +36,13 @@ type RegistryOptions struct {
 }
 
 type Model struct {
-	Name         string   `json:"-"`
-	ShortName    string   `json:"-"`
-	ModelPath    string   `json:"-"`
-	Template     string   `json:"-"`
-	System       string   `json:"-"`
-	License      []string `json:"-"`
-	RunnerDigest string   // RunnerDigest is used to identify when the loaded model should be changed
+	Name      string   `json:"-"`
+	ShortName string   `json:"-"`
+	ModelPath string   `json:"-"`
+	Template  string   `json:"-"`
+	System    string   `json:"-"`
+	License   []string `json:"-"`
+	Digest    string   // used to identify when the loaded model should be changed
 	// these fields are used to determine the RunnerDigest
 	BaseModel    string                 `json:"baseModel"`
 	AdapterPaths []string               `json:"adapterPaths"`
@@ -233,16 +233,16 @@ func GetModel(name string) (*Model, error) {
 		}
 	}
 
-	runnerDigest, err := runnerDigest(model)
+	digest, err := digest(model)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate runner digest: %v", err)
 	}
-	model.RunnerDigest = runnerDigest
+	model.Digest = digest
 
 	return model, nil
 }
 
-func runnerDigest(m *Model) (string, error) {
+func digest(m *Model) (string, error) {
 	encodedModel, err := json.Marshal(m)
 	if err != nil {
 		return "", fmt.Errorf("failed to encode model: %v", err)

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/jmorganca/ollama/api"
+	"github.com/jmorganca/ollama/vector"
 )
 
 func TestModelPrompt(t *testing.T) {
@@ -19,5 +20,107 @@ func TestModelPrompt(t *testing.T) {
 	want := "a<h1>b"
 	if s != want {
 		t.Errorf("got %q, want %q", s, want)
+	}
+}
+
+func TestRunnerDigest_Success(t *testing.T) {
+	model := &Model{
+		Name:          "TestModel",
+		ShortName:     "TM",
+		ModelPath:     "/path/to/model",
+		OriginalModel: "Original",
+		AdapterPaths:  []string{"/path/1", "/path/2"},
+		License:       []string{"MIT"},
+		Options:       map[string]interface{}{"key": "value"},
+		Embeddings:    []vector.Embedding{{Vector: []float64{1.0, 2.0}, Data: "data1"}},
+	}
+
+	_, err := runnerDigest(model)
+	if err != nil {
+		t.Errorf("Failed to create digest: %v", err)
+	}
+}
+
+func TestRunnerDigest_DifferentModels(t *testing.T) {
+	model1 := &Model{
+		Name:          "TestModel",
+		ShortName:     "TM",
+		ModelPath:     "/path/to/model",
+		OriginalModel: "Original",
+		AdapterPaths:  []string{"/path/1", "/path/2"},
+		License:       []string{"MIT"},
+		Options:       map[string]interface{}{"key": "value"},
+		Embeddings:    []vector.Embedding{{Vector: []float64{1.0, 2.0}, Data: "data1"}},
+	}
+
+	model2 := &Model{
+		Name:          "AnotherModel",
+		ShortName:     "AM",
+		ModelPath:     "/another/path",
+		OriginalModel: "DifferentOriginal",
+		AdapterPaths:  []string{"/path/3"},
+		License:       []string{"Apache"},
+		Options:       map[string]interface{}{"newKey": "newValue"},
+		Embeddings:    []vector.Embedding{{Vector: []float64{3.0, 4.0}, Data: "data2"}},
+	}
+
+	digest1, _ := runnerDigest(model1)
+	digest2, _ := runnerDigest(model2)
+
+	if digest1 == digest2 {
+		t.Error("Different models should have different digests")
+	}
+}
+
+func TestRunnerDigest_SameDigestDifferentTemplate(t *testing.T) {
+	model := &Model{
+		Name:     "TestModel",
+		Template: "Template1",
+		Embeddings: []vector.Embedding{
+			{Vector: []float64{1.0, 2.0}, Data: "data1"},
+		},
+	}
+	digest1, _ := runnerDigest(model)
+
+	model.Template = "Template2"
+	digest2, _ := runnerDigest(model)
+
+	if digest1 != digest2 {
+		t.Error("Changing only the Template should not change the digest")
+	}
+}
+
+func TestRunnerDigest_SameDigestDifferentSystem(t *testing.T) {
+	model := &Model{
+		Name:   "TestModel",
+		System: "System1",
+		Embeddings: []vector.Embedding{
+			{Vector: []float64{1.0, 2.0}, Data: "data1"},
+		},
+	}
+	digest1, _ := runnerDigest(model)
+
+	model.System = "System2"
+	digest2, _ := runnerDigest(model)
+
+	if digest1 != digest2 {
+		t.Error("Changing only the System should not change the digest")
+	}
+}
+
+func TestRunnerDigest_DifferentEmbeddings(t *testing.T) {
+	model := &Model{
+		Name: "TestModel",
+		Embeddings: []vector.Embedding{
+			{Vector: []float64{1.0, 2.0}, Data: "data1"},
+		},
+	}
+	digest1, _ := runnerDigest(model)
+
+	model.Embeddings = append(model.Embeddings, vector.Embedding{Vector: []float64{3.0, 4.0}, Data: "data2"})
+	digest2, _ := runnerDigest(model)
+
+	if digest1 == digest2 {
+		t.Error("Changing the Embeddings should change the digest")
 	}
 }

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/jmorganca/ollama/api"
-	"github.com/jmorganca/ollama/vector"
 )
 
 func TestModelPrompt(t *testing.T) {
@@ -32,7 +31,6 @@ func TestRunnerDigest_Success(t *testing.T) {
 		AdapterPaths:  []string{"/path/1", "/path/2"},
 		License:       []string{"MIT"},
 		Options:       map[string]interface{}{"key": "value"},
-		Embeddings:    []vector.Embedding{{Vector: []float64{1.0, 2.0}, Data: "data1"}},
 	}
 
 	_, err := runnerDigest(model)
@@ -50,7 +48,6 @@ func TestRunnerDigest_DifferentModels(t *testing.T) {
 		AdapterPaths:  []string{"/path/1", "/path/2"},
 		License:       []string{"MIT"},
 		Options:       map[string]interface{}{"key": "value"},
-		Embeddings:    []vector.Embedding{{Vector: []float64{1.0, 2.0}, Data: "data1"}},
 	}
 
 	model2 := &Model{
@@ -61,7 +58,6 @@ func TestRunnerDigest_DifferentModels(t *testing.T) {
 		AdapterPaths:  []string{"/path/3"},
 		License:       []string{"Apache"},
 		Options:       map[string]interface{}{"newKey": "newValue"},
-		Embeddings:    []vector.Embedding{{Vector: []float64{3.0, 4.0}, Data: "data2"}},
 	}
 
 	digest1, _ := runnerDigest(model1)
@@ -76,9 +72,6 @@ func TestRunnerDigest_SameDigestDifferentTemplate(t *testing.T) {
 	model := &Model{
 		Name:     "TestModel",
 		Template: "Template1",
-		Embeddings: []vector.Embedding{
-			{Vector: []float64{1.0, 2.0}, Data: "data1"},
-		},
 	}
 	digest1, _ := runnerDigest(model)
 
@@ -94,9 +87,6 @@ func TestRunnerDigest_SameDigestDifferentSystem(t *testing.T) {
 	model := &Model{
 		Name:   "TestModel",
 		System: "System1",
-		Embeddings: []vector.Embedding{
-			{Vector: []float64{1.0, 2.0}, Data: "data1"},
-		},
 	}
 	digest1, _ := runnerDigest(model)
 
@@ -105,22 +95,5 @@ func TestRunnerDigest_SameDigestDifferentSystem(t *testing.T) {
 
 	if digest1 != digest2 {
 		t.Error("Changing only the System should not change the digest")
-	}
-}
-
-func TestRunnerDigest_DifferentEmbeddings(t *testing.T) {
-	model := &Model{
-		Name: "TestModel",
-		Embeddings: []vector.Embedding{
-			{Vector: []float64{1.0, 2.0}, Data: "data1"},
-		},
-	}
-	digest1, _ := runnerDigest(model)
-
-	model.Embeddings = append(model.Embeddings, vector.Embedding{Vector: []float64{3.0, 4.0}, Data: "data2"})
-	digest2, _ := runnerDigest(model)
-
-	if digest1 == digest2 {
-		t.Error("Changing the Embeddings should change the digest")
 	}
 }

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -33,7 +33,7 @@ func TestRunnerDigest_Success(t *testing.T) {
 		Options:      map[string]interface{}{"key": "value"},
 	}
 
-	_, err := runnerDigest(model)
+	_, err := digest(model)
 	if err != nil {
 		t.Errorf("Failed to create digest: %v", err)
 	}
@@ -60,8 +60,8 @@ func TestRunnerDigest_DifferentModels(t *testing.T) {
 		Options:      map[string]interface{}{"newKey": "newValue"},
 	}
 
-	digest1, _ := runnerDigest(model1)
-	digest2, _ := runnerDigest(model2)
+	digest1, _ := digest(model1)
+	digest2, _ := digest(model2)
 
 	if digest1 == digest2 {
 		t.Error("Different models should have different digests")
@@ -73,10 +73,10 @@ func TestRunnerDigest_SameDigestDifferentTemplate(t *testing.T) {
 		Name:     "TestModel",
 		Template: "Template1",
 	}
-	digest1, _ := runnerDigest(model)
+	digest1, _ := digest(model)
 
 	model.Template = "Template2"
-	digest2, _ := runnerDigest(model)
+	digest2, _ := digest(model)
 
 	if digest1 != digest2 {
 		t.Error("Changing only the Template should not change the digest")
@@ -88,10 +88,10 @@ func TestRunnerDigest_SameDigestDifferentSystem(t *testing.T) {
 		Name:   "TestModel",
 		System: "System1",
 	}
-	digest1, _ := runnerDigest(model)
+	digest1, _ := digest(model)
 
 	model.System = "System2"
-	digest2, _ := runnerDigest(model)
+	digest2, _ := digest(model)
 
 	if digest1 != digest2 {
 		t.Error("Changing only the System should not change the digest")

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -24,13 +24,13 @@ func TestModelPrompt(t *testing.T) {
 
 func TestRunnerDigest_Success(t *testing.T) {
 	model := &Model{
-		Name:          "TestModel",
-		ShortName:     "TM",
-		ModelPath:     "/path/to/model",
-		OriginalModel: "Original",
-		AdapterPaths:  []string{"/path/1", "/path/2"},
-		License:       []string{"MIT"},
-		Options:       map[string]interface{}{"key": "value"},
+		Name:         "TestModel",
+		ShortName:    "TM",
+		ModelPath:    "/path/to/model",
+		BaseModel:    "Original",
+		AdapterPaths: []string{"/path/1", "/path/2"},
+		License:      []string{"MIT"},
+		Options:      map[string]interface{}{"key": "value"},
 	}
 
 	_, err := runnerDigest(model)
@@ -41,23 +41,23 @@ func TestRunnerDigest_Success(t *testing.T) {
 
 func TestRunnerDigest_DifferentModels(t *testing.T) {
 	model1 := &Model{
-		Name:          "TestModel",
-		ShortName:     "TM",
-		ModelPath:     "/path/to/model",
-		OriginalModel: "Original",
-		AdapterPaths:  []string{"/path/1", "/path/2"},
-		License:       []string{"MIT"},
-		Options:       map[string]interface{}{"key": "value"},
+		Name:         "TestModel",
+		ShortName:    "TM",
+		ModelPath:    "/path/to/model",
+		BaseModel:    "Original",
+		AdapterPaths: []string{"/path/1", "/path/2"},
+		License:      []string{"MIT"},
+		Options:      map[string]interface{}{"key": "value"},
 	}
 
 	model2 := &Model{
-		Name:          "AnotherModel",
-		ShortName:     "AM",
-		ModelPath:     "/another/path",
-		OriginalModel: "DifferentOriginal",
-		AdapterPaths:  []string{"/path/3"},
-		License:       []string{"Apache"},
-		Options:       map[string]interface{}{"newKey": "newValue"},
+		Name:         "AnotherModel",
+		ShortName:    "AM",
+		ModelPath:    "/another/path",
+		BaseModel:    "DifferentOriginal",
+		AdapterPaths: []string{"/path/3"},
+		License:      []string{"Apache"},
+		Options:      map[string]interface{}{"newKey": "newValue"},
 	}
 
 	digest1, _ := runnerDigest(model1)


### PR DESCRIPTION
Say I have 2 models, both are based on llama2, but they have different prompts.
```
FROM llama2
TEMPLATE """
you are a dog
"""
```
and
```
FROM llama2
TEMPLATE """
you are a cat
"""
```
If I am building something that swaps requests between these models a lot our current logic will re-load the models every time, even though the only thing changing is the prompt template. 

This change adds a `runner digest` which uses only fields relevant to running the model to determine if a running model should be swapped out.

As a side-effect, this also fixes the `/show modelfile` to actually show the library model name, rather than the file name when using a base model.
```
ollama run mistral
>>> /show modelfile
# Modelfile generated by "ollama show"
# To build a new Modelfile based on this one, replace the FROM line with:
# FROM mistral:latest

FROM registry.ollama.ai/library/mistral:latest
TEMPLATE """[INST] {{ .Prompt }} [/INST]
"""
SYSTEM """"""
```

- Also remove calculation on system prompt from template that makes sure the first system command is kept via `num_keep`. This isn't needed with our new prompt templates.

Resolves #337 