### PR TITLE
Fix go test./... issue: fmt.Println arg list ends with redundant newline

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -687,7 +687,7 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 				switch args[1] {
 				case "license":
 					if resp.License == "" {
-						fmt.Println("No license was specified for this model.\n")
+						fmt.Print("No license was specified for this model.\n\n")
 					} else {
 						fmt.Println(resp.License)
 					}
@@ -695,19 +695,19 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 					fmt.Println(resp.Modelfile)
 				case "parameters":
 					if resp.Parameters == "" {
-						fmt.Println("No parameters were specified for this model.\n")
+						fmt.Print("No parameters were specified for this model.\n\n")
 					} else {
 						fmt.Println(resp.Parameters)
 					}
 				case "system":
 					if resp.System == "" {
-						fmt.Println("No system prompt was specified for this model.\n")
+						fmt.Print("No system prompt was specified for this model.\n\n")
 					} else {
 						fmt.Println(resp.System)
 					}
 				case "template":
 					if resp.Template == "" {
-						fmt.Println("No prompt template was specified for this model.\n")
+						fmt.Print("No prompt template was specified for this model.\n\n")
 					} else {
 						fmt.Println(resp.Template)
 					}


### PR DESCRIPTION
`go test ./...` currently fails with:

```
# github.com/jmorganca/ollama/cmd
cmd/cmd.go:690:7: fmt.Println arg list ends with redundant newline
cmd/cmd.go:698:7: fmt.Println arg list ends with redundant newline
cmd/cmd.go:704:7: fmt.Println arg list ends with redundant newline
cmd/cmd.go:710:7: fmt.Println arg list ends with redundant newline
?       github.com/jmorganca/ollama     [no test files]
?       github.com/jmorganca/ollama/api [no test files]
?       github.com/jmorganca/ollama/llm [no test files]
?       github.com/jmorganca/ollama/llm/llama.cpp       [no test files]
?       github.com/jmorganca/ollama/parser      [no test files]
?       github.com/jmorganca/ollama/progressbar [no test files]
ok      github.com/jmorganca/ollama/format      0.003s
?       github.com/jmorganca/ollama/vector      [no test files]
?       github.com/jmorganca/ollama/version     [no test files]
ok      github.com/jmorganca/ollama/server      0.005s
FAIL
```

This commit changes fmt.Println to just fmt.Print so that `go test ./...` passes:

```
?       github.com/jmorganca/ollama     [no test files]
?       github.com/jmorganca/ollama/api [no test files]
?       github.com/jmorganca/ollama/cmd [no test files]
?       github.com/jmorganca/ollama/llm [no test files]
?       github.com/jmorganca/ollama/llm/llama.cpp       [no test files]
?       github.com/jmorganca/ollama/parser      [no test files]
?       github.com/jmorganca/ollama/progressbar [no test files]
ok      github.com/jmorganca/ollama/format      (cached)
?       github.com/jmorganca/ollama/vector      [no test files]
?       github.com/jmorganca/ollama/version     [no test files]
ok      github.com/jmorganca/ollama/server      (cached)
```

I'm on Arch Linux using Go 1.21.1 linux/amd64.