### PR TITLE
Use Go 1.21 in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.21
 WORKDIR /go/src/github.com/jmorganca/ollama
 COPY . .
 RUN CGO_ENABLED=1 go build -ldflags '-linkmode external -extldflags "-static"' .


### PR DESCRIPTION
I have tested Ollama with Go 1.21 on macOS and Arch Linux and everything works here.

This commit bumps `FROM golang:1.20` to `FROM golang:1.21`.