### PR TITLE
not found error before pulling model

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net"
 	"net/http"
@@ -170,6 +172,11 @@ func GenerateHandler(c *gin.Context) {
 
 	model, err := GetModel(req.Model)
 	if err != nil {
+		var pErr *fs.PathError
+		if errors.As(err, &pErr) {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("model '%s' not found, try pulling it first", req.Model)})
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
When attempting to run a model through the API before pulling it a cryptic "no such file or directory" error was returned with the error path. 

Improve this error to suggest pulling the model first, like the CLI does automatically.
```
curl -X 'POST' -d '{"prompt":"hello", "model": "mistral"}' 'http://127.0.0.1:11434/api/generate'
{"error":"model 'mistral' not found, try pulling it first"}%  
```

resolves #715 