### PR TITLE
relay model runner error message to client

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -479,18 +479,7 @@ func generate(cmd *cobra.Command, model, prompt string, wordWrap bool) error {
 	}
 
 	if err := client.Generate(cancelCtx, &request, fn); err != nil {
-		if strings.Contains(err.Error(), "failed to load model") {
-			// tell the user to check the server log, if it exists locally
-			home, nestedErr := os.UserHomeDir()
-			if nestedErr != nil {
-				// return the original error
-				return err
-			}
-			logPath := filepath.Join(home, ".ollama", "logs", "server.log")
-			if _, nestedErr := os.Stat(logPath); nestedErr == nil {
-				err = fmt.Errorf("%w\nFor more details, check the error logs at %s", err, logPath)
-			}
-		} else if strings.Contains(err.Error(), "context canceled") && abort {
+		if strings.Contains(err.Error(), "context canceled") && abort {
 			spinner.Finish()
 			return nil
 		}

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -377,7 +377,6 @@ func newLlama(model string, adapters []string, runners []ModelRunner, numLayers 
 		return nil, runnerErr
 	}
 
-	// if you update this error message, also update the error check in cmd.generate()
 	return nil, fmt.Errorf("failed to start a llama runner")
 }
 

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -263,7 +263,6 @@ func (w *StatusWriter) Write(b []byte) (int, error) {
 	if _, after, ok := bytes.Cut(b, []byte("error:")); ok {
 		err := fmt.Errorf("llama runner: %s", after)
 		w.ErrCh <- err
-		return os.Stderr.Write(b)
 	}
 	return os.Stderr.Write(b)
 }


### PR DESCRIPTION
This got missed in the migration to subprocesses. 

Old error displayed in CLI:
```
failed to start llama runner
```

New error (will relay the actual error from the model runner):
```
Error: llama runner failed: out of memory
```

resolves #630 