### PR TITLE
add feedback for reading model metadata

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -374,6 +374,7 @@ func CreateModel(ctx context.Context, workDir, name string, path string, fn func
 			}
 
 			if mf != nil {
+				fn(api.ProgressResponse{Status: "reading model metadata"})
 				sourceBlobPath, err := GetBlobsPath(mf.Config.Digest)
 				if err != nil {
 					return err


### PR DESCRIPTION
When creating a model from a large base layer (ex: 70B) reading model metadata is slow since the weights file is large.

Without feedback here the creation is in the "looking for model" stage for a long time, which makes it look like something has gone wrong.

New behavior:
```
parsing modelfile
looking for model
⠋ reading model metadata
```