### PR TITLE
improve vram safety with 5% vram memory buffer

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -377,11 +377,11 @@ func (llm *llama) Close() {
 	}()
 	select {
 	case err := <-done:
+		msg := "llama runner exited"
 		if err != nil {
-			log.Printf("llama runner exited with error: %v", err)
-		} else {
-			log.Printf("llama runner exited gracefully")
+			msg = fmt.Sprintf("%s: %v", msg, err)
 		}
+		log.Print(msg)
 	case <-time.After(5 * time.Second):
 		log.Printf("waiting for llama runner to close timed out after 5 seconds")
 	}

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -371,19 +371,8 @@ func (llm *llama) Close() {
 	llm.Cancel()
 
 	// wait for the command to exit to prevent race conditions with the next run
-	done := make(chan error, 1)
-	go func() {
-		done <- llm.Cmd.Wait()
-	}()
-	select {
-	case err := <-done:
-		msg := "llama runner exited"
-		if err != nil {
-			msg = fmt.Sprintf("%s: %v", msg, err)
-		}
-		log.Print(msg)
-	case <-time.After(5 * time.Second):
-		log.Printf("waiting for llama runner to close timed out after 5 seconds")
+	if err := llm.Cmd.Wait(); err != nil {
+		log.Printf("llama runner exited: %v", err)
 	}
 }
 

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -234,8 +234,8 @@ func NumGPU(numLayer, fileSizeBytes int64, opts api.Options) int {
 		// TODO: this is a rough heuristic, better would be to calculate this based on number of layers and context size
 		bytesPerLayer := fileSizeBytes / numLayer
 
-		// max number of layers we can fit in VRAM, subtract 10% to prevent consuming all available VRAM and running out of memory
-		layers := int(totalVramBytes/bytesPerLayer) * 9 / 10
+		// max number of layers we can fit in VRAM, subtract 5% to prevent consuming all available VRAM and running out of memory
+		layers := int(totalVramBytes/bytesPerLayer) * 95 / 100
 		log.Printf("%d MiB VRAM available, loading up to %d GPU layers", vramMib, layers)
 
 		return layers

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -234,8 +234,8 @@ func NumGPU(numLayer, fileSizeBytes int64, opts api.Options) int {
 		// TODO: this is a rough heuristic, better would be to calculate this based on number of layers and context size
 		bytesPerLayer := fileSizeBytes / numLayer
 
-		// max number of layers we can fit in VRAM
-		layers := int(totalVramBytes / bytesPerLayer)
+		// max number of layers we can fit in VRAM, subtract 10% to prevent consuming all available VRAM and running out of memory
+		layers := int(totalVramBytes/bytesPerLayer) * 9 / 10
 		log.Printf("%d MiB VRAM available, loading up to %d GPU layers", vramMib, layers)
 
 		return layers

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -191,7 +191,7 @@ var errNoGPU = errors.New("nvidia-smi command failed")
 
 // CheckVRAM returns the available VRAM in MiB on Linux machines with NVIDIA GPUs
 func CheckVRAM() (int64, error) {
-	cmd := exec.Command("nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits")
+	cmd := exec.Command("nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	err := cmd.Run()

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -228,14 +228,14 @@ func NumGPU(numLayer, fileSizeBytes int64, opts api.Options) int {
 			return 0
 		}
 
-		totalVramBytes := int64(vramMib) * 1024 * 1024 // 1 MiB = 1024^2 bytes
+		freeVramBytes := int64(vramMib) * 1024 * 1024 // 1 MiB = 1024^2 bytes
 
 		// Calculate bytes per layer
 		// TODO: this is a rough heuristic, better would be to calculate this based on number of layers and context size
 		bytesPerLayer := fileSizeBytes / numLayer
 
 		// max number of layers we can fit in VRAM, subtract 5% to prevent consuming all available VRAM and running out of memory
-		layers := int(totalVramBytes/bytesPerLayer) * 95 / 100
+		layers := int(freeVramBytes/bytesPerLayer) * 95 / 100
 		log.Printf("%d MiB VRAM available, loading up to %d GPU layers", vramMib, layers)
 
 		return layers


### PR DESCRIPTION
In testing how much VRAM should be allocated we typically used a model which could be entirely loaded into VRAM. This masked an issue when a model is larger than the available VRAM it is possible to consume all available VRAM and fail with an error:
```
Error: llama runner failed: out of memory
```

This change leaves a 10% buffer on available VRAM to prevent running out of memory.

Tested on a T4:
- `llama2:7b`: easily offloads all layers to GPU
- `llama2:13b`: easily offloads all layers to GPU
- `llama2:70b`: offloaded 29 layers to GPU, was slow but did not run out of memory on load (as it did before)


Resolves #725