### PR TITLE
handle upstream proxies

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -1486,7 +1486,18 @@ func makeRequest(ctx context.Context, method string, requestURL *url.URL, header
 		req.ContentLength = contentLength
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	proxyURL, err := http.ProxyFromEnvironment(req)
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(proxyURL),
+		},
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`http.ProxyFromEnvironment` returns the appropriate `*_PROXY` for the request. e.g. `HTTP_PROXY` for `http://` requests, `HTTPS_PROXY` for `https://` requests.

This is only applied to requests from the server to the upstream registry. This change can also be applied from the ollama client to the server