### PR TITLE
concurrent uploads

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -134,7 +134,6 @@ func (b *blobDownload) Run(ctx context.Context, requestURL *url.URL, opts *Regis
 
 func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *RegistryOptions) error {
 	defer blobDownloadManager.Delete(b.Digest)
-
 	ctx, b.CancelFunc = context.WithCancel(ctx)
 
 	file, err := os.OpenFile(b.Name+"-partial", os.O_CREATE|os.O_RDWR, 0644)
@@ -170,7 +169,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *Regis
 				}
 			}
 
-			return errors.New("max retries exceeded")
+			return errMaxRetriesExceeded
 		})
 	}
 
@@ -307,6 +306,8 @@ type downloadOpts struct {
 }
 
 const maxRetries = 3
+
+var errMaxRetriesExceeded = errors.New("max retries exceeded")
 
 // downloadBlob downloads a blob from the registry and stores it in the blobs directory
 func downloadBlob(ctx context.Context, opts downloadOpts) error {

--- a/server/routes.go
+++ b/server/routes.go
@@ -365,7 +365,9 @@ func PushModelHandler(c *gin.Context) {
 			Insecure: req.Insecure,
 		}
 
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+
 		if err := PushModel(ctx, req.Name, regOpts, fn); err != nil {
 			ch <- gin.H{"error": err.Error()}
 		}

--- a/server/upload.go
+++ b/server/upload.go
@@ -175,7 +175,7 @@ func (b *blobUpload) Run(ctx context.Context, opts *RegistryOptions) {
 	headers.Set("Content-Type", "application/octet-stream")
 	headers.Set("Content-Length", "0")
 
-	resp, err := makeRequest(ctx, "PUT", requestURL, headers, nil, opts)
+	resp, err := makeRequestWithRetry(ctx, "PUT", requestURL, headers, nil, opts)
 	if err != nil {
 		b.err = err
 		return


### PR DESCRIPTION
follow a similar pattern as downloads with some key differences:

1. uploads parts are serialized based on a nextURL channel which informs the next part where to upload to
2. redirects send to nextURL before following the redirect which allows parts to be uploaded concurrently
3. progress is tracked with blobUploadWriter which tracks how many bytes per part is written. this is necessary for redirect which partially reads the initial request before following the redirect; it needs to rewind the overall progress

TODO: 
- [ ] verify calculated md5 with etag and retry the part if it differs