### PR TITLE
add version api and show server version in cli

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -311,3 +311,15 @@ func (c *Client) CreateBlob(ctx context.Context, digest string, r io.Reader) err
 
 	return nil
 }
+
+func (c *Client) Version(ctx context.Context) (string, error) {
+	var version struct {
+		Version string `json:"version"`
+	}
+
+	if err := c.do(ctx, http.MethodGet, "/api/version", nil, &version); err != nil {
+		return "", err
+	}
+
+	return version.Version, nil
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1050,7 +1050,9 @@ func versionHandler(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	fmt.Printf("server version %s\n", serverVersion)
+	if serverVersion != version.Version {
+		fmt.Printf("ollama host version %s\n", serverVersion)
+	}
 }
 
 func NewCLI() *cobra.Command {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1037,8 +1037,25 @@ func checkServerHeartbeat(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+func versionHandler(cmd *cobra.Command, _ []string) {
+	fmt.Printf("ollama version %s\n", version.Version)
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return
+	}
+
+	serverVersion, err := client.Version(cmd.Context())
+	if err != nil {
+		return
+	}
+
+	fmt.Printf("server version %s\n", serverVersion)
+}
+
 func NewCLI() *cobra.Command {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	cobra.EnableCommandSorting = false
 
 	rootCmd := &cobra.Command{
 		Use:           "ollama",
@@ -1049,9 +1066,17 @@ func NewCLI() *cobra.Command {
 			DisableDefaultCmd: true,
 		},
 		Version: version.Version,
+		Run: func(cmd *cobra.Command, args []string) {
+			if version, _ := cmd.Flags().GetBool("version"); version {
+				versionHandler(cmd, args)
+				return
+			}
+
+			cmd.Print(cmd.UsageString())
+		},
 	}
 
-	cobra.EnableCommandSorting = false
+	rootCmd.Flags().BoolP("version", "v", false, "Show version information")
 
 	createCmd := &cobra.Command{
 		Use:     "create MODEL",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1038,8 +1038,6 @@ func checkServerHeartbeat(cmd *cobra.Command, _ []string) error {
 }
 
 func versionHandler(cmd *cobra.Command, _ []string) {
-	fmt.Printf("ollama version %s\n", version.Version)
-
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return
@@ -1047,11 +1045,15 @@ func versionHandler(cmd *cobra.Command, _ []string) {
 
 	serverVersion, err := client.Version(cmd.Context())
 	if err != nil {
-		return
+		fmt.Println("Warning: could not connect to a running Ollama instance")
+	}
+
+	if serverVersion != "" {
+		fmt.Printf("ollama version is %s\n", serverVersion)
 	}
 
 	if serverVersion != version.Version {
-		fmt.Printf("ollama host version %s\n", serverVersion)
+		fmt.Printf("Warning: client version is %s\n", version.Version)
 	}
 }
 
@@ -1067,7 +1069,6 @@ func NewCLI() *cobra.Command {
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
-		Version: version.Version,
 		Run: func(cmd *cobra.Command, args []string) {
 			if version, _ := cmd.Flags().GetBool("version"); version {
 				versionHandler(cmd, args)

--- a/server/routes.go
+++ b/server/routes.go
@@ -782,6 +782,9 @@ func Serve(ln net.Listener, allowOrigins []string) error {
 		})
 
 		r.Handle(method, "/api/tags", ListModelsHandler)
+		r.Handle(method, "/api/version", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"version": version.Version})
+		})
 	}
 
 	log.Printf("Listening on %s (version %s)", ln.Addr(), version.Version)


### PR DESCRIPTION
some minor refactor of the cmd package

Example: server and client are the same version
```
$ ollama --version
Your ollama version 0.0.0
```

Example: server and client have different versions
```
$ ollama --version
Your ollama version 99.99.99999
Warning: Your client version is 0.0.0
```

Example: server is not accessible
```
$ ollama --version
Warning: Your server is not accessible
Your client version is 0.0.0
```
