### PR TITLE
show request to server rather than local check

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -694,7 +694,12 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 		case strings.HasPrefix(line, "/show"):
 			args := strings.Fields(line)
 			if len(args) > 1 {
-				resp, err := server.GetModelInfo(model)
+				client, err := api.ClientFromEnvironment()
+				if err != nil {
+					fmt.Println("error: couldn't connect to ollama server")
+					return err
+				}
+				resp, err := client.Show(cmd.Context(), &api.ShowRequest{Name: model})
 				if err != nil {
 					fmt.Println("error: couldn't get model")
 					return err


### PR DESCRIPTION
The show command should send a request to the server, rather than making a direct call to the function locally.

resolces #776 