### PR TITLE
Fix link to api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ Finally, in a separate shell, run a model:
 
 ## REST API
 
-> See the [API documentation](docs/api.md) for all endpoints.
+**See the [API documentation](docs/api.md) for all endpoints.**
+
 
 Ollama has an API for running and managing models. For example to generate text from a model:
 


### PR DESCRIPTION
It seems that the link to the API docs doesn't work for some reason. After some investigation, I think the GitHub markdown fails to match the relative path for `docs/api.md` because of the quote block.

I submitted this PR in case you want a quick fix until you find out what exactly is wrong.

Thanks!