### PR TITLE
fix: offloading on low end GPUs

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -215,6 +215,11 @@ func CheckVRAM() (int64, error) {
 		free += vram
 	}
 
+	if free*1024*1024 < 2*1000*1000*1000 {
+		log.Printf("less than 2 GB VRAM available, falling back to CPU only")
+		free = 0
+	}
+
 	return free, nil
 }
 


### PR DESCRIPTION
Fixes two issues when using low end GPUs:

GPUs with low VRAM are disproportionately affected by overhead when offloading so any device that has less than 2GB VRAM will be exclusively CPU unless overwritten by num_gpu.

A CUDA-enabled runner will still offload to GPU even if num_gpu is 0. This is problematic when the GPU doesn't support a compatible version of CUDA. In this case, select the CPU runner instead.

Caveat: for MacOS (darwin) `go generate` only builds Metal on ARM so it shouldn't be marked as `Accelerated` since there's no fallback