### PR TITLE
Fix JSON Marshal Escaping for Special Characters

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -544,10 +544,17 @@ func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string,
 		Stop:             llm.Stop,
 	}
 
-	data, err := json.Marshal(predReq)
-	if err != nil {
-		return fmt.Errorf("error marshaling data: %v", err)
+	// Handling JSON marshaling with special characters unescaped.
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(predReq); err != nil {
+		return fmt.Errorf("failed to marshal data: %v", err)
 	}
+
+	// Remove trailing newline added by Encode.
+	data := buf.Bytes()[:buf.Len()-1]
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(data))
 	if err != nil {


### PR DESCRIPTION
Fixed the json.Marshal() behavior in llama.go to prevent automatic escaping of special characters like < and >. This ensures templates with these characters are correctly represented in the JSON output. Addresses issue https://github.com/jmorganca/ollama/issues/798