### PR TITLE
API docs link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Finally, in a separate shell, run a model:
 
 ## REST API
 
-> See the [API documentation](docs/api.md) for all endpoints.
+> See the [API documentation](https://github.com/jmorganca/ollama/blob/main/docs/api.md) for all endpoints.
 
 Ollama has an API for running and managing models. For example to generate text from a model:
 


### PR DESCRIPTION
For some reason, the relative API docs link is broken (api is a particular path in Github). 
Replaced the API docs link in README.md with the absolute path.

Fixes issue #802.