### PR TITLE
refactor llm/llama.go

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -531,16 +531,14 @@ func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string,
 			// This handles the request cancellation
 			return ctx.Err()
 		default:
-			line := scanner.Text()
-			if line == "" {
+			line := scanner.Bytes()
+			if len(line) == 0 {
 				continue
 			}
 
-			// Read data from the server-side event stream
-			if strings.HasPrefix(line, "data: ") {
-				evt := line[6:]
+			if evt, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
 				var p prediction
-				if err := json.Unmarshal([]byte(evt), &p); err != nil {
+				if err := json.Unmarshal(evt, &p); err != nil {
 					return fmt.Errorf("error unmarshaling llm prediction response: %v", err)
 				}
 


### PR DESCRIPTION
- remove unused struct GenerationSettings
- remove a layer of indirection for prediction request. it's only used in one place so it's nicer to have a `map[string]any` instead of a struct
- nest `Timings` for similar reasons
- use `CutPrefix` to both check for `data:` and trimming