### PR TITLE
Fix /api/tags for no models.

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -481,7 +481,7 @@ func GetModelInfo(name string) (*api.ShowResponse, error) {
 }
 
 func ListModelsHandler(c *gin.Context) {
-	var models []api.ModelResponse
+	models := make([]api.ModelResponse, 0)
 	fp, err := GetManifestPath()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})


### PR DESCRIPTION
When the `.ollama` folder is broken, or no models exist, `/api/tags` returns `{models: null}` instead of the expected `{models: []}`.

Please review the change as minor as it is, as my experience with Go is close to nil.