### PR TITLE
show: no template system if empty

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -951,7 +951,10 @@ func ShowModelfile(model *Model) (string, error) {
 
 FROM {{ .From }}
 TEMPLATE """{{ .Template }}"""
+
+{{- if .System }}
 SYSTEM """{{ .System }}"""
+{{- end }}
 {{ .Params }}
 `
 	for _, l := range mt.Model.AdapterPaths {


### PR DESCRIPTION
This prevents show outputs like this:

```
ollama run mistral
>>> /show modelfile
# Modelfile generated by "ollama show"
# To build a new Modelfile based on this one, replace the FROM line with:
# FROM mistral:latest

FROM registry.ollama.ai/library/mistral:latest
TEMPLATE """[INST] {{ .Prompt }} [/INST]
"""
SYSTEM """"""
```