### PR TITLE
Fix Issue with Leading Whitespaces in Decoded Context

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -465,7 +465,7 @@ func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string,
 	}
 
 	// Remove leading spaces from prevConvo if present
-	prevConvo = strings.TrimLeft(prevConvo, " ")
+	prevConvo = strings.TrimPrefix(prevConvo, " ")
 
 	var nextContext strings.Builder
 	nextContext.WriteString(prevConvo)

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -464,6 +464,11 @@ func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string,
 		return err
 	}
 
+	// Remove first leading space from prevConvo if present
+	if len(prevConvo) > 0 && prevConvo[0] == ' ' {
+		prevConvo = prevConvo[1:]
+	}
+
 	var nextContext strings.Builder
 	nextContext.WriteString(prevConvo)
 	nextContext.WriteString(prompt)
@@ -666,7 +671,7 @@ func (llm *llama) Decode(ctx context.Context, tokens []int) (string, error) {
 	}
 
 	// decoded content contains a leading whitespace
-	decoded.Content, _ = strings.CutPrefix(decoded.Content, " ")
+	decoded.Content, _ = strings.CutPrefix(decoded.Content, "")
 
 	return decoded.Content, nil
 }

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -668,9 +668,6 @@ func (llm *llama) Decode(ctx context.Context, tokens []int) (string, error) {
 		return "", fmt.Errorf("unmarshal encode response: %w", err)
 	}
 
-	// decoded content contains a leading whitespace
-	decoded.Content, _ = strings.CutPrefix(decoded.Content, "")
-
 	return decoded.Content, nil
 }
 

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -464,10 +464,8 @@ func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string,
 		return err
 	}
 
-	// Remove first leading space from prevConvo if present
-	if len(prevConvo) > 0 && prevConvo[0] == ' ' {
-		prevConvo = prevConvo[1:]
-	}
+	// Remove leading spaces from prevConvo if present
+	prevConvo = strings.TrimLeft(prevConvo, " ")
 
 	var nextContext strings.Builder
 	nextContext.WriteString(prevConvo)

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -666,7 +666,7 @@ func (llm *llama) Decode(ctx context.Context, tokens []int) (string, error) {
 	}
 
 	// decoded content contains a leading whitespace
-	decoded.Content, _ = strings.CutPrefix(decoded.Content, "")
+	decoded.Content, _ = strings.CutPrefix(decoded.Content, " ")
 
 	return decoded.Content, nil
 }


### PR DESCRIPTION
This Pull Request addresses a bug in the Decode function where leading whitespaces are not properly removed from the decoded context.

I have tested the behavior both before and after making this change:

- Before: The leading whitespaces were present when using the context.
- After: The leading whitespaces were properly removed.