### PR TITLE
Contribution of Ollama Public IP API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,4 @@ curl -X POST http://localhost:11434/api/generate -d '{
 - [oterm](https://github.com/ggozad/oterm)
 - [Ellama Emacs client](https://github.com/s-kostyaev/ellama)
 - [OllamaSharp for .NET](https://github.com/awaescher/OllamaSharp)
+- [Ollama Public IP API](https://github.com/AyushDhimann/OllamaServer)


### PR DESCRIPTION
I have created a GitHub [repo](https://github.com/AyushDhimann/OllamaServer) which with only one command, installs Ollama and the LLM model of choice on the Linux web server, and generates a publicly available IP using nginx, so that LLM's could be run and accessed through Linux web servers.

My main motivation for this contribution was to run Microsoft's AutoGen by loading LLM's from my server and some custom integration too.