### PR TITLE
fix: ollama host for hostname

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -52,8 +52,10 @@ func ClientFromEnvironment() (*Client, error) {
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
 		host, port = "127.0.0.1", "11434"
-		if ip := net.ParseIP(strings.Trim(os.Getenv("OLLAMA_HOST"), "[]")); ip != nil {
+		if ip := net.ParseIP(strings.Trim(hostport, "[]")); ip != nil {
 			host = ip.String()
+		} else if hostport != "" {
+			host = hostport
 		}
 	}
 


### PR DESCRIPTION
This fixes the client when setting `OLLAMA_HOST` to just the hostname, e.g. `OLLAMA_HOST=myhost`. `OLLAMA_HOST=myhost:11434` currently works as does `OLLAMA_HOST=127.0.0.1` and `OLLAMA_HOST=127.0.0.1:11434`