### PR TITLE
fix/Predict: A prediction should use the options sent with the request

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -161,6 +161,12 @@ func (r *GenerateResponse) Summary() {
 	}
 }
 
+// Options are all the options
+type Options struct {
+	Runner
+	PredictOptions
+}
+
 // Runner options which must be set when the model is loaded into memory
 type Runner struct {
 	UseNUMA            bool    `json:"numa,omitempty"`
@@ -181,8 +187,8 @@ type Runner struct {
 	NumThread          int     `json:"num_thread,omitempty"`
 }
 
-type Options struct {
-	Runner
+// PredictOptions are the options used at runtime
+type PredictOptions struct {
 
 	// Predict options used at runtime
 	NumKeep          int      `json:"num_keep,omitempty"`
@@ -292,22 +298,24 @@ func (opts *Options) FromMap(m map[string]interface{}) error {
 func DefaultOptions() Options {
 	return Options{
 		// options set on request to runner
-		NumPredict:       -1,
-		NumKeep:          -1,
-		Temperature:      0.8,
-		TopK:             40,
-		TopP:             0.9,
-		TFSZ:             1.0,
-		TypicalP:         1.0,
-		RepeatLastN:      64,
-		RepeatPenalty:    1.1,
-		PresencePenalty:  0.0,
-		FrequencyPenalty: 0.0,
-		Mirostat:         0,
-		MirostatTau:      5.0,
-		MirostatEta:      0.1,
-		PenalizeNewline:  true,
-		Seed:             -1,
+		PredictOptions: PredictOptions{
+			NumPredict:       -1,
+			NumKeep:          -1,
+			Temperature:      0.8,
+			TopK:             40,
+			TopP:             0.9,
+			TFSZ:             1.0,
+			TypicalP:         1.0,
+			RepeatLastN:      64,
+			RepeatPenalty:    1.1,
+			PresencePenalty:  0.0,
+			FrequencyPenalty: 0.0,
+			Mirostat:         0,
+			MirostatTau:      5.0,
+			MirostatEta:      0.1,
+			PenalizeNewline:  true,
+			Seed:             -1,
+		},
 
 		Runner: Runner{
 			// options set when the model is loaded

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -473,7 +473,7 @@ type prediction struct {
 
 const maxBufferSize = 512 * format.KiloByte
 
-func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string, fn func(api.GenerateResponse)) error {
+func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string, options api.PredictOptions, fn func(api.GenerateResponse)) error {
 	prevConvo, err := llm.Decode(ctx, prevContext)
 	if err != nil {
 		return err
@@ -489,23 +489,23 @@ func (llm *llama) Predict(ctx context.Context, prevContext []int, prompt string,
 	request := map[string]any{
 		"prompt":            nextContext.String(),
 		"stream":            true,
-		"n_predict":         llm.NumPredict,
-		"n_keep":            llm.NumKeep,
-		"temperature":       llm.Temperature,
-		"top_k":             llm.TopK,
-		"top_p":             llm.TopP,
-		"tfs_z":             llm.TFSZ,
-		"typical_p":         llm.TypicalP,
-		"repeat_last_n":     llm.RepeatLastN,
-		"repeat_penalty":    llm.RepeatPenalty,
-		"presence_penalty":  llm.PresencePenalty,
-		"frequency_penalty": llm.FrequencyPenalty,
-		"mirostat":          llm.Mirostat,
-		"mirostat_tau":      llm.MirostatTau,
-		"mirostat_eta":      llm.MirostatEta,
-		"penalize_nl":       llm.PenalizeNewline,
-		"seed":              llm.Seed,
-		"stop":              llm.Stop,
+		"n_predict":         options.NumPredict,
+		"n_keep":            options.NumKeep,
+		"temperature":       options.Temperature,
+		"top_k":             options.TopK,
+		"top_p":             options.TopP,
+		"tfs_z":             options.TFSZ,
+		"typical_p":         options.TypicalP,
+		"repeat_last_n":     options.RepeatLastN,
+		"repeat_penalty":    options.RepeatPenalty,
+		"presence_penalty":  options.PresencePenalty,
+		"frequency_penalty": options.FrequencyPenalty,
+		"mirostat":          options.Mirostat,
+		"mirostat_tau":      options.MirostatTau,
+		"mirostat_eta":      options.MirostatEta,
+		"penalize_nl":       options.PenalizeNewline,
+		"seed":              options.Seed,
+		"stop":              options.Stop,
 	}
 
 	// Handling JSON marshaling with special characters unescaped.

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -14,7 +14,7 @@ import (
 )
 
 type LLM interface {
-	Predict(context.Context, []int, string, func(api.GenerateResponse)) error
+	Predict(context.Context, []int, string, api.PredictOptions, func(api.GenerateResponse)) error
 	Embedding(context.Context, string) ([]float64, error)
 	Encode(context.Context, string) ([]int, error)
 	Decode(context.Context, []int) (string, error)

--- a/server/routes.go
+++ b/server/routes.go
@@ -214,7 +214,12 @@ func GenerateHandler(c *gin.Context) {
 			ch <- r
 		}
 
-		if err := loaded.runner.Predict(c.Request.Context(), req.Context, prompt, fn); err != nil {
+		opts := api.DefaultOptions()
+		if err := opts.FromMap(req.Options); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if err := loaded.runner.Predict(c.Request.Context(), req.Context, prompt, opts.PredictOptions, fn); err != nil {
 			ch <- gin.H{"error": err.Error()}
 		}
 	}()


### PR DESCRIPTION
Consecutive query to the same running model should use the client request parameters instead of the one set during the model loading.