### PR TITLE
fix: nil pointer dereference

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -106,6 +106,7 @@ func getAuthToken(ctx context.Context, redirData AuthRedirect) (string, error) {
 	resp, err := makeRequest(ctx, "GET", redirectURL, headers, nil, nil)
 	if err != nil {
 		log.Printf("couldn't get token: %q", err)
+		return "", err
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
if the token request returns an error, e.g. the token server isn't running, resp is dereferenced and panics