### PR TITLE
update runtime options

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -112,6 +112,10 @@ func load(ctx context.Context, workDir string, model *Model, reqOpts map[string]
 		loaded.Options = &opts
 	}
 
+	// update options for the loaded llm
+	// TODO(mxyng): this isn't thread safe, but it should be fine for now
+	loaded.runner.SetOptions(opts)
+
 	loaded.expireAt = time.Now().Add(sessionDuration)
 
 	if loaded.expireTimer == nil {


### PR DESCRIPTION
SetOptions doesn't differentiate between boot or runtime options but that's not relevant. By the time SetOptions is called, the LLM is already running so any boot option updates will be ignored