### PR TITLE
doc: fix link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Finally, in a separate shell, run a model:
 
 ## REST API
 
-> See the [API documentation](docs/api.md) for all endpoints.
+> See the [API documentation](https://github.com/jmorganca/ollama/blob/main/docs/api.md) for all endpoints.
 
 Ollama has an API for running and managing models. For example to generate text from a model:
 


### PR DESCRIPTION
I'm pretty sure the style of link you were using used to work.

It may be a bug on the side of @GitHub, but the current link doesn't work anymore.

Note: a `../` style relative link to the blob won't work because there are two paths from which the link could be linked:

- https://github.com/jmorganca/ollama/
- https://github.com/jmorganca/ollama/blob/main/README.md

# Preview

https://github.com/coolaj86/ollama/tree/patch-3