### PR TITLE
fix: Add support for legacy CPU (no AVX2/FMA) on Linux

### DIFF
--- a/llm/llama.cpp/generate_linux.go
+++ b/llm/llama.cpp/generate_linux.go
@@ -11,6 +11,10 @@ package llm
 //go:generate cmake --build ggml/build/cpu --target server --config Release
 //go:generate mv ggml/build/cpu/bin/server ggml/build/cpu/bin/ollama-runner
 
+//go:generate cmake -S ggml -B ggml/build/legacy-cpu -DLLAMA_K_QUANTS=on -DLLAMA_AVX2=off -DLLAMA_FMA=off
+//go:generate cmake --build ggml/build/legacy-cpu --target server --config Release
+//go:generate mv ggml/build/legacy-cpu/bin/server ggml/build/legacy-cpu/bin/ollama-runner
+
 //go:generate git submodule update --force gguf
 //go:generate git -C gguf apply ../patches/0001-copy-cuda-runtime-libraries.patch
 //go:generate git -C gguf apply ../patches/0001-remove-warm-up-logging.patch
@@ -18,9 +22,22 @@ package llm
 //go:generate cmake --build gguf/build/cpu --target server --config Release
 //go:generate mv gguf/build/cpu/bin/server gguf/build/cpu/bin/ollama-runner
 
+//go:generate cmake -S gguf -B gguf/build/legacy-cpu -DLLAMA_K_QUANTS=on -DLLAMA_AVX2=off -DLLAMA_FMA=off
+//go:generate cmake --build gguf/build/legacy-cpu --target server --config Release
+//go:generate mv gguf/build/legacy-cpu/bin/server gguf/build/legacy-cpu/bin/ollama-runner
+
 //go:generate cmake -S ggml -B ggml/build/cuda -DLLAMA_CUBLAS=on -DLLAMA_ACCELERATE=on -DLLAMA_K_QUANTS=on
 //go:generate cmake --build ggml/build/cuda --target server --config Release
 //go:generate mv ggml/build/cuda/bin/server ggml/build/cuda/bin/ollama-runner
+
+//go:generate cmake -S ggml -B ggml/build/cuda-legacy-cpu -DLLAMA_CUBLAS=on -DLLAMA_ACCELERATE=on -DLLAMA_K_QUANTS=on -DLLAMA_AVX2=off -DLLAMA_FMA=off
+//go:generate cmake --build ggml/build/cuda-legacy-cpu --target server --config Release
+//go:generate mv ggml/build/cuda-legacy-cpu/bin/server ggml/build/cuda-legacy-cpu/bin/ollama-runner
+
 //go:generate cmake -S gguf -B gguf/build/cuda -DLLAMA_CUBLAS=on -DLLAMA_ACCELERATE=on -DLLAMA_K_QUANTS=on
 //go:generate cmake --build gguf/build/cuda --target server --config Release
 //go:generate mv gguf/build/cuda/bin/server gguf/build/cuda/bin/ollama-runner
+
+//go:generate cmake -S gguf -B gguf/build/cuda-legacy-cpu -DLLAMA_CUBLAS=on -DLLAMA_ACCELERATE=on -DLLAMA_K_QUANTS=on -DLLAMA_AVX2=off -DLLAMA_FMA=off
+//go:generate cmake --build gguf/build/cuda-legacy-cpu --target server --config Release
+//go:generate mv gguf/build/cuda-legacy-cpu/bin/server gguf/build/cuda-legacy-cpu/bin/ollama-runner

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -34,7 +34,7 @@ var llamaCppEmbed embed.FS
 type ModelRunner struct {
 	Path        string // path to the model runner executable
 	Accelerated bool
-	LegacyCPU	bool
+	LegacyCPU   bool
 }
 
 func chooseRunners(workDir, runnerType string) []ModelRunner {
@@ -124,7 +124,7 @@ func chooseRunners(workDir, runnerType string) []ModelRunner {
 		localRunnersByPriority = append(localRunnersByPriority, ModelRunner{
 			Path:        filepath.Clean(path.Join(workDir, r.Path)),
 			Accelerated: r.Accelerated,
-			LegacyCPU:	 r.LegacyCPU,
+			LegacyCPU:   r.LegacyCPU,
 		})
 	}
 


### PR DESCRIPTION
Fixes the illegal instruction error when running with CPU without AVX2 or FMA, by building another set of ollama runner with `-DLLAMA_AVX2=off -DLLAMA_FMA=off`.

By default, upon running the cmake for ggml/gguf, it will have these arguments set to ON. Setting it to OFF, allows older CPU that don't have these instruction to be able to run the llama.cpp.  

fixes #644

Some sources for the AVX2 and FMA compatibility:
- [CPUs_with_AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX2)
- [CPUs_with_FMA3](https://en.wikipedia.org/wiki/FMA_instruction_set#CPUs_with_FMA3)