### PR TITLE
fix readme for linux : port address already in use

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -17,6 +17,8 @@ sudo chmod +x /usr/bin/ollama
 
 ## Start Ollama
 
+NOTE : If you are trying to run Ollama after fresh installation then you can skip to step running model (Since Ollama server should already be running at port number 11434 after a fresh installation)
+
 Start Ollama by running `ollama serve`:
 
 ```bash
@@ -27,6 +29,14 @@ Once Ollama is running, run a model in another terminal session:
 
 ```bash
 ollama run llama2
+```
+
+## Stop Ollama
+
+Stop Ollama by running `systemctl stop ollama`:
+
+```bash
+systemctl stop ollama
 ```
 
 ## Install CUDA drivers (optional – for Nvidia GPUs)


### PR DESCRIPTION
If user is installing Ollama for the first time/fresh install then Ollama server is started automatically. So when you try 
```
ollama serve
```
then it throws error - 127.0.0.1:11434: bind: address already in use 
So instead of running this command user can skip to running model

This PR patches the corresponding fixes in documentation for linux
Fixes: https://github.com/jmorganca/ollama/issues/707