### PR TITLE
Temporary Workaround for GGUF v3 Support

### DIFF
--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -32,7 +32,11 @@ func (c *containerGGUF) Decode(r io.Reader) (model, error) {
 	switch c.Version {
 	case 1:
 		binary.Read(r, binary.LittleEndian, &c.V1)
-	case 2:
+	case 2, 3:
+		// TODO: This workaround allows handling of version 3 by treating it as version 2.
+		// A more comprehensive solution is needed to address any potential differences between versions 2 and 3,
+		// especially if there are updates to the Llama submodule or the GGUF specification in the future.
+		// Consider refactoring this block to properly handle version 3.
 		binary.Read(r, binary.LittleEndian, &c.V2)
 	default:
 		return nil, errors.New("invalid version")


### PR DESCRIPTION
Addresses the problem raised in Issue #877.

This pull request introduces a temporary workaround to support the GGUF container specification version 3 by treating it as version 2 within the switch case block in `llm/gguf.go`. This change ensures that the new models utilizing version 3 can be processed correctly in the interim.

I am hesitant to even suggest that such workarounds be merged. However, this branch could serve as a temporary solution for others until a more robust fix is deployed. I intend to use this branch to work with models quantized by TheBloke in the meantime.

I have tested it against new v3 models and v2 models:
```bash
$ ollama run agentlm-7b:Q4_K_M "Hi"
Hello! How can I assist you today?

$ ollama run samantha-1.2-mistral-7b:Q4_K_M "Hi"
Hello! I'm glad you decided to say hello. What would you like to talk about today? I'm here for a friendly conversation and to provide support whenever you need it.

$ ollama run zephyr-7b-alpha:Q4_K_M "Hi"
Hello! How can I assist you?
```