### PR TITLE
allow for a configurable ollama model storage directory

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -18,10 +18,6 @@ import (
 	"github.com/jmorganca/ollama/version"
 )
 
-const DefaultHost = "127.0.0.1:11434"
-
-var envHost = os.Getenv("OLLAMA_HOST")
-
 type Client struct {
 	base *url.URL
 	http http.Client

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,10 +61,6 @@ systemctl restart ollama
 - macOS: Raw model data is stored under `~/.ollama/models`.
 - Linux: Raw model data is stored under `/usr/share/ollama/.ollama/models`
 
-## How can I change where Ollama stores models?
+### How can I change where Ollama stores models?
 
-By default, Ollama stores files in the `~/.ollama/models` directory. To modify this, you can use the `OLLAMA_MODELS` environment variable.
-
-### Setting `OLLAMA_MODELS` in Linux environments
-
-Define `OLLAMA_MODELS` in the `/etc/systemd/system/ollama.service` service file.
+To modify where models are stored, you can use the `OLLAMA_MODELS` environment variable. Note that on Linux this means defining `OLLAMA_MODELS` in the `/etc/systemd/system/ollama.service` service file.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,4 +63,4 @@ systemctl restart ollama
 
 ### How can I change where Ollama stores models?
 
-To modify where models are stored, you can use the `OLLAMA_MODELS` environment variable. Note that on Linux this means defining `OLLAMA_MODELS` in the `/etc/systemd/system/ollama.service` service file.
+To modify where models are stored, you can use the `OLLAMA_MODELS` environment variable. Note that on Linux this means defining `OLLAMA_MODELS` in a drop-in `/etc/systemd/system/ollama.service.d` service file, reloading systemd, and restarting the ollama service.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -60,3 +60,11 @@ systemctl restart ollama
 
 - macOS: Raw model data is stored under `~/.ollama/models`.
 - Linux: Raw model data is stored under `/usr/share/ollama/.ollama/models`
+
+## How can I change where Ollama stores models?
+
+By default, Ollama stores files in the `~/.ollama/models` directory. To modify this, you can use the `OLLAMA_MODELS` environment variable.
+
+### Setting `OLLAMA_MODELS` in Linux environments
+
+Define `OLLAMA_MODELS` in the `/etc/systemd/system/ollama.service` service file.

--- a/server/images.go
+++ b/server/images.go
@@ -131,7 +131,7 @@ func (m *ManifestV2) GetTotalSize() (total int64) {
 }
 
 func GetManifest(mp ModelPath) (*ManifestV2, string, error) {
-	fp, err := mp.GetManifestPath(false)
+	fp, err := mp.GetManifestPath()
 	if err != nil {
 		return nil, "", err
 	}
@@ -595,8 +595,11 @@ func CreateManifest(name string, cfg *LayerReader, layers []*Layer) error {
 		return err
 	}
 
-	fp, err := mp.GetManifestPath(true)
+	fp, err := mp.GetManifestPath()
 	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
 		return err
 	}
 	return os.WriteFile(fp, manifestJSON, 0o644)
@@ -710,14 +713,17 @@ func CreateLayer(f io.ReadSeeker) (*LayerReader, error) {
 
 func CopyModel(src, dest string) error {
 	srcModelPath := ParseModelPath(src)
-	srcPath, err := srcModelPath.GetManifestPath(false)
+	srcPath, err := srcModelPath.GetManifestPath()
 	if err != nil {
 		return err
 	}
 
 	destModelPath := ParseModelPath(dest)
-	destPath, err := destModelPath.GetManifestPath(true)
+	destPath, err := destModelPath.GetManifestPath()
 	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return err
 	}
 
@@ -882,7 +888,7 @@ func DeleteModel(name string) error {
 		return err
 	}
 
-	fp, err := mp.GetManifestPath(false)
+	fp, err := mp.GetManifestPath()
 	if err != nil {
 		return err
 	}
@@ -1121,8 +1127,11 @@ func PullModel(ctx context.Context, name string, regOpts *RegistryOptions, fn fu
 		return err
 	}
 
-	fp, err := mp.GetManifestPath(true)
+	fp, err := mp.GetManifestPath()
 	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
 		return err
 	}
 

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -85,9 +85,9 @@ func (mp ModelPath) GetShortTagname() string {
 	return fmt.Sprintf("%s/%s/%s:%s", mp.Registry, mp.Namespace, mp.Repository, mp.Tag)
 }
 
-// ModelsDir returns the value of the OLLAMA_MODELS environment variable or the user's home directory if OLLAMA_MODELS is not set.
+// modelsDir returns the value of the OLLAMA_MODELS environment variable or the user's home directory if OLLAMA_MODELS is not set.
 // The models directory is where Ollama stores its model files and manifests.
-func ModelsDir() (string, error) {
+func modelsDir() (string, error) {
 	if models, exists := os.LookupEnv("OLLAMA_MODELS"); exists {
 		return models, nil
 	}
@@ -100,7 +100,7 @@ func ModelsDir() (string, error) {
 
 // GetManifestPath returns the path to the manifest file for the given model path, it is up to the caller to create the directory if it does not exist.
 func (mp ModelPath) GetManifestPath() (string, error) {
-	dir, err := ModelsDir()
+	dir, err := modelsDir()
 	if err != nil {
 		return "", err
 	}
@@ -116,7 +116,7 @@ func (mp ModelPath) BaseURL() *url.URL {
 }
 
 func GetManifestPath() (string, error) {
-	dir, err := ModelsDir()
+	dir, err := modelsDir()
 	if err != nil {
 		return "", err
 	}
@@ -130,7 +130,7 @@ func GetManifestPath() (string, error) {
 }
 
 func GetBlobsPath(digest string) (string, error) {
-	dir, err := ModelsDir()
+	dir, err := modelsDir()
 	if err != nil {
 		return "", err
 	}

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -85,13 +85,37 @@ func (mp ModelPath) GetShortTagname() string {
 	return fmt.Sprintf("%s/%s/%s:%s", mp.Registry, mp.Namespace, mp.Repository, mp.Tag)
 }
 
-func (mp ModelPath) GetManifestPath(createDir bool) (string, error) {
+// ModelsDir returns the value of the OLLAMA_MODELS environment variable or the user's home directory if OLLAMA_MODELS is not set.
+// The models directory is where Ollama stores its model files and manifests.
+func ModelsDir() (string, error) {
+	if models, exists := os.LookupEnv("OLLAMA_MODELS"); exists {
+		dir, err := os.Stat(models)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return "", fmt.Errorf("OLLAMA_MODELS is set to %q but that directory does not exist", models)
+		case errors.Is(err, os.ErrPermission):
+			return "", fmt.Errorf("OLLAMA_MODELS is set to %q but that directory is not accessible", models)
+		case err != nil:
+			return "", fmt.Errorf("failed to validate OLLAMA_MODELS directory %q: %w", models, err)
+		case !dir.IsDir():
+			return "", fmt.Errorf("OLLAMA_MODELS is set to %q but that is not a directory", models)
+		}
+		return models, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
+	return filepath.Join(home, ".ollama", "models"), nil
+}
 
-	path := filepath.Join(home, ".ollama", "models", "manifests", mp.Registry, mp.Namespace, mp.Repository, mp.Tag)
+func (mp ModelPath) GetManifestPath(createDir bool) (string, error) {
+	dir, err := ModelsDir()
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(dir, "manifests", mp.Registry, mp.Namespace, mp.Repository, mp.Tag)
 	if createDir {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return "", err
@@ -109,12 +133,12 @@ func (mp ModelPath) BaseURL() *url.URL {
 }
 
 func GetManifestPath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := ModelsDir()
 	if err != nil {
 		return "", err
 	}
 
-	path := filepath.Join(home, ".ollama", "models", "manifests")
+	path := filepath.Join(dir, "manifests")
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return "", err
 	}
@@ -123,7 +147,7 @@ func GetManifestPath() (string, error) {
 }
 
 func GetBlobsPath(digest string) (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := ModelsDir()
 	if err != nil {
 		return "", err
 	}
@@ -132,7 +156,7 @@ func GetBlobsPath(digest string) (string, error) {
 		digest = strings.ReplaceAll(digest, ":", "-")
 	}
 
-	path := filepath.Join(home, ".ollama", "models", "blobs", digest)
+	path := filepath.Join(dir, "blobs", digest)
 	dirPath := filepath.Dir(path)
 	if digest == "" {
 		dirPath = path

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -98,6 +98,7 @@ func ModelsDir() (string, error) {
 	return filepath.Join(home, ".ollama", "models"), nil
 }
 
+// GetManifestPath returns the path to the manifest file for the given model path, it is up to the caller to create the directory if it does not exist.
 func (mp ModelPath) GetManifestPath() (string, error) {
 	dir, err := ModelsDir()
 	if err != nil {

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -89,17 +89,6 @@ func (mp ModelPath) GetShortTagname() string {
 // The models directory is where Ollama stores its model files and manifests.
 func ModelsDir() (string, error) {
 	if models, exists := os.LookupEnv("OLLAMA_MODELS"); exists {
-		dir, err := os.Stat(models)
-		switch {
-		case errors.Is(err, os.ErrNotExist):
-			return "", fmt.Errorf("OLLAMA_MODELS is set to %q but that directory does not exist", models)
-		case errors.Is(err, os.ErrPermission):
-			return "", fmt.Errorf("OLLAMA_MODELS is set to %q but that directory is not accessible", models)
-		case err != nil:
-			return "", fmt.Errorf("failed to validate OLLAMA_MODELS directory %q: %w", models, err)
-		case !dir.IsDir():
-			return "", fmt.Errorf("OLLAMA_MODELS is set to %q but that is not a directory", models)
-		}
 		return models, nil
 	}
 	home, err := os.UserHomeDir()
@@ -109,20 +98,13 @@ func ModelsDir() (string, error) {
 	return filepath.Join(home, ".ollama", "models"), nil
 }
 
-func (mp ModelPath) GetManifestPath(createDir bool) (string, error) {
+func (mp ModelPath) GetManifestPath() (string, error) {
 	dir, err := ModelsDir()
 	if err != nil {
 		return "", err
 	}
 
-	path := filepath.Join(dir, "manifests", mp.Registry, mp.Namespace, mp.Repository, mp.Tag)
-	if createDir {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return "", err
-		}
-	}
-
-	return path, nil
+	return filepath.Join(dir, "manifests", mp.Registry, mp.Namespace, mp.Repository, mp.Tag), nil
 }
 
 func (mp ModelPath) BaseURL() *url.URL {


### PR DESCRIPTION
- set `OLLAMA_MODELS` in the environment that ollama is running in to change where models are stored
- update docs

```bash
$ OLLAMA_MODELS=/Users/bruce/ollama_models ollama serve
# store models and public keys in /Users/bruce/ollama_models
```

Resolves #228

I'll hold off on merging this until #847 is in to avoid causing that PR pain.