### PR TITLE
add bracketed paste mode

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -553,6 +553,9 @@ func generateInteractive(cmd *cobra.Command, model string) error {
 		wordWrap = false
 	}
 
+	fmt.Print(readline.StartBracketedPaste)
+	defer fmt.Printf(readline.EndBracketedPaste)
+
 	var multiLineBuffer string
 
 	for {

--- a/readline/types.go
+++ b/readline/types.go
@@ -72,6 +72,14 @@ const (
 
 const (
 	CharBracketedPaste      = 50
-	CharBracketedPasteStart = 0
-	CharBracketedPasteEnd   = 1
+	CharBracketedPasteStart = "00~"
+	CharBracketedPasteEnd   = "01~"
+)
+
+type PasteMode int
+
+const (
+	PastModeOff = iota
+	PasteModeStart
+	PasteModeEnd
 )


### PR DESCRIPTION
This change allows you to cut/paste into the REPL without have to add the """ around a block of text.

I've tested it out with:
  * Terminal.app
  * iTerm2
  * Warp

