### PR TITLE
catch insufficient permissions nvidia err

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -212,6 +212,10 @@ func CheckVRAM() (int64, error) {
 	scanner := bufio.NewScanner(&stdout)
 	for scanner.Scan() {
 		line := scanner.Text()
+		if strings.Contains(line, "[Insufficient Permissions]") {
+			return 0, fmt.Errorf("GPU support may not enabled, check you have installed GPU drivers and have the necessary permissions to run nvidia-smi")
+		}
+
 		vram, err := strconv.ParseInt(strings.TrimSpace(line), 10, 64)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse available VRAM: %v", err)


### PR DESCRIPTION
If there is an insufficient permissions error on `nvidia-smi` execution if would be logged as a parsing error. Catch the error before this happens.

#932 