### PR TITLE
clean up: remove server functions from client

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -614,6 +614,22 @@ var defaultAllowOrigins = []string{
 }
 
 func Serve(ln net.Listener, allowOrigins []string) error {
+	if noprune := os.Getenv("OLLAMA_NOPRUNE"); noprune == "" {
+		// clean up unused layers and manifests
+		if err := PruneLayers(); err != nil {
+			return err
+		}
+
+		manifestsPath, err := GetManifestPath()
+		if err != nil {
+			return err
+		}
+
+		if err := PruneDirectory(manifestsPath); err != nil {
+			return err
+		}
+	}
+
 	config := cors.DefaultConfig()
 	config.AllowWildcard = true
 


### PR DESCRIPTION
We have had trouble with cross-account file permission when the Ollama client and server are running as different users. This change is a small clean up to remove all calls to server package code from the client (except for `server.Run()`), from now on we should not call anymore server package functions from `cmd` to prevent bugs.