### PR TITLE
Don't quit ioloop on `NUL` character

### DIFF
--- a/readline/buffer.go
+++ b/readline/buffer.go
@@ -45,7 +45,7 @@ func (b *Buffer) MoveLeft() {
 		if b.Pos%b.LineWidth == 0 {
 			fmt.Printf(CursorUp + CursorBOL + cursorRightN(b.Width))
 		} else {
-			fmt.Printf(CursorLeft)
+			fmt.Print(CursorLeft)
 		}
 		b.Pos -= 1
 	}
@@ -78,7 +78,7 @@ func (b *Buffer) MoveRight() {
 		if b.Pos%b.LineWidth == 0 {
 			fmt.Printf(CursorDown + CursorBOL + cursorRightN(b.PromptSize()))
 		} else {
-			fmt.Printf(CursorRight)
+			fmt.Print(CursorRight)
 		}
 	}
 }
@@ -104,7 +104,7 @@ func (b *Buffer) MoveToStart() {
 		currLine := b.Pos / b.LineWidth
 		if currLine > 0 {
 			for cnt := 0; cnt < currLine; cnt++ {
-				fmt.Printf(CursorUp)
+				fmt.Print(CursorUp)
 			}
 		}
 		fmt.Printf(CursorBOL + cursorRightN(b.PromptSize()))
@@ -118,12 +118,12 @@ func (b *Buffer) MoveToEnd() {
 		totalLines := b.Size() / b.LineWidth
 		if currLine < totalLines {
 			for cnt := 0; cnt < totalLines-currLine; cnt++ {
-				fmt.Printf(CursorDown)
+				fmt.Print(CursorDown)
 			}
 			remainder := b.Size() % b.LineWidth
 			fmt.Printf(CursorBOL + cursorRightN(b.PromptSize()+remainder))
 		} else {
-			fmt.Printf(cursorRightN(b.Size() - b.Pos))
+			fmt.Print(cursorRightN(b.Size() - b.Pos))
 		}
 
 		b.Pos = b.Size()
@@ -173,15 +173,15 @@ func (b *Buffer) drawRemaining() {
 	if b.Pos > 0 {
 		place = b.Pos % b.LineWidth
 	}
-	fmt.Printf(CursorHide)
+	fmt.Print(CursorHide)
 
 	// render the rest of the current line
 	currLine := remainingText[:min(b.LineWidth-place, len(remainingText))]
 	if len(currLine) > 0 {
 		fmt.Printf(ClearToEOL + currLine)
-		fmt.Printf(cursorLeftN(len(currLine)))
+		fmt.Print(cursorLeftN(len(currLine)))
 	} else {
-		fmt.Printf(ClearToEOL)
+		fmt.Print(ClearToEOL)
 	}
 
 	// render the other lines
@@ -195,12 +195,12 @@ func (b *Buffer) drawRemaining() {
 			}
 			fmt.Printf("%c", c)
 		}
-		fmt.Printf(ClearToEOL)
-		fmt.Printf(cursorUpN(totalLines))
+		fmt.Print(ClearToEOL)
+		fmt.Print(cursorUpN(totalLines))
 		fmt.Printf(CursorBOL + cursorRightN(b.Width-len(currLine)))
 	}
 
-	fmt.Printf(CursorShow)
+	fmt.Print(CursorShow)
 }
 
 func (b *Buffer) Remove() {
@@ -305,12 +305,12 @@ func (b *Buffer) ClearScreen() {
 			targetLine := currPos / b.LineWidth
 			if targetLine > 0 {
 				for cnt := 0; cnt < targetLine; cnt++ {
-					fmt.Printf(CursorDown)
+					fmt.Print(CursorDown)
 				}
 			}
 			remainder := currPos % b.LineWidth
 			if remainder > 0 {
-				fmt.Printf(cursorRightN(remainder))
+				fmt.Print(cursorRightN(remainder))
 			}
 			if currPos%b.LineWidth == 0 {
 				fmt.Printf(CursorBOL + b.Prompt.AltPrompt)

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -75,7 +75,11 @@ func (i *Instance) Readline() (string, error) {
 			fmt.Printf(ColorGrey + ph + fmt.Sprintf(CursorLeftN, len(ph)) + ColorDefault)
 		}
 
-		r := i.Terminal.Read()
+		r, err := i.Terminal.Read()
+		if err != nil {
+			return "", io.EOF
+		}
+
 		if buf.IsEmpty() {
 			fmt.Print(ClearToEOL)
 		}
@@ -105,7 +109,11 @@ func (i *Instance) Readline() (string, error) {
 			case CharBracketedPaste:
 				var code string
 				for cnt := 0; cnt < 3; cnt++ {
-					r = i.Terminal.Read()
+					r, err = i.Terminal.Read()
+					if err != nil {
+						return "", io.EOF
+					}
+
 					code += string(r)
 				}
 				if code == CharBracketedPasteStart {
@@ -237,8 +245,13 @@ func (t *Terminal) ioloop() {
 	}
 }
 
-func (t *Terminal) Read() rune {
-	return <-t.outchan
+func (t *Terminal) Read() (rune, error) {
+	r, ok := <-t.outchan
+	if !ok {
+		return 0, io.EOF
+	}
+
+	return r, nil
 }
 
 func (t *Terminal) Close() error {

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -211,8 +211,8 @@ func (i *Instance) Readline() (string, error) {
 	}
 }
 
-func (i *Instance) Close() error {
-	return i.Terminal.Close()
+func (i *Instance) Close() {
+	i.Terminal.Close()
 }
 
 func (i *Instance) HistoryEnable() {
@@ -254,7 +254,6 @@ func (t *Terminal) Read() (rune, error) {
 	return r, nil
 }
 
-func (t *Terminal) Close() error {
+func (t *Terminal) Close() {
 	close(t.outchan)
-	return nil
 }

--- a/readline/term.go
+++ b/readline/term.go
@@ -1,4 +1,6 @@
+//go:build aix || darwin || dragonfly || freebsd || (linux && !appengine) || netbsd || openbsd || os400 || solaris
 // +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris
+
 package readline
 
 import (
@@ -30,6 +32,6 @@ func UnsetRawMode(fd int, termios *Termios) error {
 
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(fd int) bool {
-        _, err := getTermios(fd)
-        return err == nil
+	_, err := getTermios(fd)
+	return err == nil
 }

--- a/readline/types.go
+++ b/readline/types.go
@@ -1,6 +1,7 @@
 package readline
 
 const (
+	CharNull      = 0
 	CharLineStart = 1
 	CharBackward  = 2
 	CharInterrupt = 3


### PR DESCRIPTION
The `stdin` read loop would stop on receiving a `NUL` character, triggered by ctrl+space or other key combos.