### PR TITLE
support raw generation requests

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -37,6 +37,7 @@ type GenerateRequest struct {
 	Template string `json:"template"`
 	Context  []int  `json:"context,omitempty"`
 	Stream   *bool  `json:"stream,omitempty"`
+	Raw      bool   `json:"raw,omitempty"`
 
 	Options map[string]interface{} `json:"options"`
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,7 @@ Advanced parameters (optional):
 - `template`: the full prompt or prompt template (overrides what is defined in the `Modelfile`)
 - `context`: the context parameter returned from a previous request to `/generate`, this can be used to keep a short conversational memory
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
+- `raw`: if `true` no formatting will be applied to the prompt and no context will be returned. You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.
 
 ### Examples
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -137,6 +137,36 @@ If `stream` is set to `false`, the response will be a single JSON object:
 }
 ```
 
+#### Request
+
+In some cases you may wish to bypass the templating system and provide a full prompt. In this case, you can use the `raw` parameter to disable formatting and context.
+
+```shell
+curl -X POST http://localhost:11434/api/generate -d '{
+  "model": "mistral",
+  "prompt": "[INST] why is the sky blue? [/INST]",
+  "raw": true,
+  "stream": false
+}'
+```
+
+#### Response
+
+```json
+{
+  "model": "mistral",
+  "created_at": "2023-11-03T15:36:02.583064Z",
+  "response": " The sky appears blue because of a phenomenon called Rayleigh scattering.",
+  "done": true,
+  "total_duration": 14648695333,
+  "load_duration": 3302671417,
+  "prompt_eval_count": 14,
+  "prompt_eval_duration": 286243000,
+  "eval_count": 129,
+  "eval_duration": 10931424000
+}
+```
+
 ## Create a Model
 
 ```shell

--- a/server/routes.go
+++ b/server/routes.go
@@ -167,10 +167,6 @@ func GenerateHandler(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "raw mode does not support template, system, or context"})
 		return
 	}
-	if req.Model == "" {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
-		return
-	}
 
 	model, err := GetModel(req.Model)
 	if err != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -158,6 +158,15 @@ func GenerateHandler(c *gin.Context) {
 		return
 	}
 
+	// validate the request
+	switch {
+	case req.Model == "":
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
+		return
+	case req.Raw && (req.Template != "" || req.System != "" || len(req.Context) > 0):
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "raw mode does not support template, system, or context"})
+		return
+	}
 	if req.Model == "" {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
 		return
@@ -189,10 +198,13 @@ func GenerateHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
-	prompt, err := model.Prompt(req)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
+	prompt := req.Prompt
+	if !req.Raw {
+		prompt, err = model.Prompt(req)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 	}
 
 	ch := make(chan any)
@@ -213,6 +225,11 @@ func GenerateHandler(c *gin.Context) {
 			if r.Done {
 				r.TotalDuration = time.Since(checkpointStart)
 				r.LoadDuration = checkpointLoaded.Sub(checkpointStart)
+			}
+
+			if req.Raw {
+				// in raw mode the client must manage history on their own
+				r.Context = nil
 			}
 
 			ch <- r


### PR DESCRIPTION
- add the optional `raw` generate request parameter to bypass prompt formatting and response context

Add a `raw` parameter to `/generate` requests that allow directly specifying the prompt without the Ollama server applying additional formatting.
```bash
curl -X "POST" -d '{"model":"mistral", "prompt": "[INST] hi [/INST]", "raw": true, "stream": false}' 'http://127.0.0.1:11434/api/generate'
```

Example use case, few-shot prompting:
```python
import requests

def call_generate_endpoint(prompt, model="mistral", raw=True, stream=False):
    url = "http://127.0.0.1:11434/api/generate"
    formatted_prompt = f"""[INST] This is awesome! [/INST]
Postive
[INST] This is bad! [/INST]
Negative
[INST] I love this movie [/INST]
Positive
[INST] {prompt} [/INST]
"""
    
    payload = {
        "model": model,
        "prompt": formatted_prompt,
        "raw": raw,
        "stream": stream
    }
    
    response = requests.post(url, json=payload)
    
    return response.json()

resp = call_generate_endpoint("I hate this book")
print(resp.response) # Negative
```