### PR TITLE
notify that the ollama api is available after linux install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,10 @@ status "Installing ollama to $BINDIR..."
 $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 $TEMP_DIR/ollama $BINDIR/ollama
 
-install_success() { status 'Install complete. Run "ollama" from the command line.'; }
+install_success() { 
+    status 'The Ollama API is now available at 127.0.0.1:11434.'
+    status 'Install complete. Run "ollama" from the command line.';
+}
 trap install_success EXIT
 
 # Everything from this point onwards is optional.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,8 +64,8 @@ $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 $TEMP_DIR/ollama $BINDIR/ollama
 
 install_success() { 
-    status 'The Ollama API is now available at 127.0.0.1:11434.'
-    status 'Install complete. Run "ollama" from the command line.';
+    status 'The Ollama API is now available at 0.0.0.0:11434.'
+    status 'Install complete. Run "ollama" from the command line.'
 }
 trap install_success EXIT
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -133,6 +133,7 @@ if check_gpu nvidia-smi; then
 fi
 
 if ! check_gpu lspci && ! check_gpu lshw; then
+    install_success
     warning "No NVIDIA GPU detected. Ollama will run in CPU-only mode."
     exit 0
 fi


### PR DESCRIPTION
Inform the user that the Ollama API is available locally after install.
```
>>> Downloading ollama...
>>> Installing ollama to /usr/local/bin...
>>> NVIDIA CUDA drivers installed.
>>> The Ollama API is now available at 127.0.0.1:11434.
>>> Install complete. Run "ollama" from the command line.
```