### PR TITLE
fix log

### DIFF
--- a/server/upload.go
+++ b/server/upload.go
@@ -104,7 +104,7 @@ func (b *blobUpload) Prepare(ctx context.Context, requestURL *url.URL, opts *Reg
 		offset += size
 	}
 
-	log.Printf("uploading %s in %d %s part(s)", b.Digest[7:19], len(b.Parts), format.HumanBytes(size))
+	log.Printf("uploading %s in %d %s part(s)", b.Digest[7:19], len(b.Parts), format.HumanBytes(b.Parts[0].Size))
 
 	requestURL, err = url.Parse(location)
 	if err != nil {


### PR DESCRIPTION
if there's a remainder, the log line will show the remainder instead of the actual size