### PR TITLE
reformat api docs for more examples

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,7 +47,9 @@ Advanced parameters (optional):
 - `context`: the context parameter returned from a previous request to `/generate`, this can be used to keep a short conversational memory
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl -X POST http://localhost:11434/api/generate -d '{
@@ -56,9 +58,9 @@ curl -X POST http://localhost:11434/api/generate -d '{
 }'
 ```
 
-### Response
+#### Response
 
-If `stream` is not specified, or set to `true`, a stream of JSON objects is returned:
+A stream of JSON objects is returned:
 
 ```json
 {
@@ -102,6 +104,18 @@ To calculate how fast the response is generated in tokens per second (token/s), 
 }
 ```
 
+#### Request
+
+```shell
+curl -X POST http://localhost:11434/api/generate -d '{
+  "model": "llama2:7b",
+  "prompt": "Why is the sky blue?",
+  "stream": false
+}'
+```
+
+#### Response
+
 If `stream` is set to `false`, the response will be a single JSON object:
 
 ```json
@@ -136,7 +150,9 @@ Create a model from a [`Modelfile`](./modelfile.md)
 - `path`: path to the Modelfile
 - `stream`: (optional) if `false` the response will be returned as a single response object, rather than a stream of objects
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl -X POST http://localhost:11434/api/create -d '{
@@ -145,7 +161,7 @@ curl -X POST http://localhost:11434/api/create -d '{
 }'
 ```
 
-### Response
+#### Response
 
 A stream of JSON objects. When finished, `status` is `success`.
 
@@ -202,7 +218,9 @@ Show details about a model including modelfile, template, parameters, license, a
 
 - `name`: name of the model to show
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl http://localhost:11434/api/show -d '{
@@ -210,7 +228,7 @@ curl http://localhost:11434/api/show -d '{
 }'
 ```
 
-### Response
+#### Response
 
 ```json
 {
@@ -229,7 +247,9 @@ POST /api/copy
 
 Copy a model. Creates a model with another name from an existing model.
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl http://localhost:11434/api/copy -d '{
@@ -238,7 +258,7 @@ curl http://localhost:11434/api/copy -d '{
 }'
 ```
 
-### Response
+#### Response
 
 The only response is a 200 OK if successful.
 
@@ -254,7 +274,9 @@ Delete a model and its data.
 
 - `name`: model name to delete
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl -X DELETE http://localhost:11434/api/delete -d '{
@@ -262,7 +284,7 @@ curl -X DELETE http://localhost:11434/api/delete -d '{
 }'
 ```
 
-### Response
+#### Response
 
 If successful, the only response is a 200 OK.
 
@@ -280,7 +302,9 @@ Download a model from the ollama library. Cancelled pulls are resumed from where
 - `insecure`: (optional) allow insecure connections to the library. Only use this if you are pulling from your own library during development.
 - `stream`: (optional) if `false` the response will be returned as a single response object, rather than a stream of objects
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl -X POST http://localhost:11434/api/pull -d '{
@@ -288,7 +312,7 @@ curl -X POST http://localhost:11434/api/pull -d '{
 }'
 ```
 
-### Response
+#### Response
 
 If `stream` is not specified, or set to `true`, a stream of JSON objects is returned:
 
@@ -306,7 +330,7 @@ Then there is a series of downloading responses. Until any of the download is co
 {
   "status": "downloading digestname",
   "digest": "digestname",
-  "total": 2142590208, 
+  "total": 2142590208,
   "completed": 241970
 }
 ```
@@ -350,7 +374,9 @@ Upload a model to a model library. Requires registering for ollama.ai and adding
 - `insecure`: (optional) allow insecure connections to the library. Only use this if you are pushing to your library during development.
 - `stream`: (optional) if `false` the response will be returned as a single response object, rather than a stream of objects
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl -X POST http://localhost:11434/api/push -d '{
@@ -358,7 +384,7 @@ curl -X POST http://localhost:11434/api/push -d '{
 }'
 ```
 
-### Response
+#### Response
 
 If `stream` is not specified, or set to `true`, a stream of JSON objects is returned:
 
@@ -396,7 +422,7 @@ Finally, when the upload is complete:
 If `stream` is set to `false`, then the response is a single JSON object:
 
 ```json
-{"status":"success"}
+{ "status": "success" }
 ```
 
 ## Generate Embeddings
@@ -416,7 +442,9 @@ Advanced parameters:
 
 - `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.md#valid-parameters-and-values) such as `temperature`
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl -X POST http://localhost:11434/api/embeddings -d '{
@@ -425,7 +453,7 @@ curl -X POST http://localhost:11434/api/embeddings -d '{
 }'
 ```
 
-### Response
+#### Response
 
 ```json
 {

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,13 +179,15 @@ GET /api/tags
 
 List models that are available locally.
 
-### Request
+### Examples
+
+#### Request
 
 ```shell
 curl http://localhost:11434/api/tags
 ```
 
-### Response
+#### Response
 
 A single JSON object will be returned.
 


### PR DESCRIPTION
I'd like to add an example for raw requests in #952 to the docs, but that requires formatting them in way that is more friendly to multiple request/responses. This change moves request/response under an "examples" header.