### PR TITLE
remove modelfile context deprecated in v0.0.7

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -63,15 +63,11 @@ func (m *Model) Prompt(request api.GenerateRequest) (string, error) {
 		First  bool
 		System string
 		Prompt string
-
-		// deprecated: versions <= 0.0.7 used this to omit the system prompt
-		Context []int
 	}
 
 	vars.First = len(request.Context) == 0
 	vars.System = m.System
 	vars.Prompt = request.Prompt
-	vars.Context = request.Context
 
 	if request.System != "" {
 		vars.System = request.System


### PR DESCRIPTION
This modelfile variable was deprecated in ollama v0.0.7, which was a very early stage of the project. It was also not documented anywhere, and no longer used in our library images. It should be ok to remove this now.