### PR TITLE
Add `encode` and `decode` API endpoints

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -52,6 +52,28 @@ type EmbeddingResponse struct {
 	Embedding []float64 `json:"embedding"`
 }
 
+type EncodeRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+
+	Options map[string]interface{} `json:"options"`
+}
+
+type EncodeResponse struct {
+	Tokens []int `json:"tokens"`
+}
+
+type DecodeRequest struct {
+	Model  string `json:"model"`
+	Tokens []int  `json:"tokens"`
+
+	Options map[string]interface{} `json:"options"`
+}
+
+type DecodeResponse struct {
+	Prompt string `json:"prompt"`
+}
+
 type CreateRequest struct {
 	Name   string `json:"name"`
 	Path   string `json:"path"`

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,8 @@
 - [Pull a Model](#pull-a-model)
 - [Push a Model](#push-a-model)
 - [Generate Embeddings](#generate-embeddings)
+- [Encode a prompt](#encode-a-prompt)
+- [Decode tokens](#decode-tokens)
 
 ## Conventions
 
@@ -433,5 +435,77 @@ curl -X POST http://localhost:11434/api/embeddings -d '{
     0.5670403838157654, 0.009260174818336964, 0.23178744316101074, -0.2916173040866852, -0.8924556970596313,
     0.8785552978515625, -0.34576427936553955, 0.5742510557174683, -0.04222835972905159, -0.137906014919281
   ]
+}
+```
+
+## Encode a prompt
+
+```shell
+POST /api/encode
+```
+
+Generate prompt tokens from a model
+
+### Parameters
+
+- `model`: name of model to generate tokens from
+- `prompt`: text to encode
+
+Advanced parameters:
+
+- `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.md#valid-parameters-and-values) such as `temperature`
+
+### Request
+
+```shell
+curl -X POST http://localhost:11434/api/encode -d '{
+  "model": "mistral:7b",
+  "prompt": "<|im_start|>system\nHello world<|im_end|>"
+}'
+```
+
+### Response
+
+```json
+{
+  "tokens": [
+    523,28766,321,28730,2521,28766,28767,6574,13,16230,1526,28789,28766,321,28730,416,28766,28767
+  ]
+}
+```
+
+## Decode tokens
+
+```shell
+POST /api/decode
+```
+
+Decode text into tokens from a model
+
+### Parameters
+
+- `model`: name of model to generate tokens from
+- `tokens`: token array
+
+Advanced parameters:
+
+- `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.md#valid-parameters-and-values) such as `temperature`
+
+### Request
+
+```shell
+curl -X POST http://localhost:11434/api/decode -d '{
+  "model": "mistral:7b",
+  "tokens": [
+    523,28766,321,28730,2521,28766,28767,6574,13,16230,1526,28789,28766,321,28730,416,28766,28767
+  ]
+}'
+```
+
+### Response
+
+```json
+{
+  "prompt": "<|im_start|>system\nHello world<|im_end|>"
 }
 ```


### PR DESCRIPTION
While working on a POC project for the company I work at I've come across the need for encoding and decoding prompts.

We are building a long-term memory POC and that requires token management, as of now we cannot predict how long the token list of a prompt might be.

This PR creates the following endpoints:

- `/api/encode`
- `/api/decode`

Both endpoints together with the existing ones will give us the flexibility to smartly manage prompt tokens.