### PR TITLE
add hass-ollama-conversation to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,4 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ellama Emacs client](https://github.com/s-kostyaev/ellama)
 - [OllamaSharp for .NET](https://github.com/awaescher/OllamaSharp)
 - [Minimalistic React UI for Ollama Models](https://github.com/richawo/minimal-llm-ui)
+- [Hass Ollama Conversation](https://github.com/ej52/hass-ollama-conversation)


### PR DESCRIPTION
Add custom home assistant integration [hass-ollama-conversation](https://github.com/ej52/hass-ollama-conversation)