### PR TITLE
Add Ollamac to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Typescript UI](https://github.com/ollama-interface/Ollama-Gui?tab=readme-ov-file)
 - [Minimalistic React UI for Ollama Models](https://github.com/richawo/minimal-llm-ui)
 - [Web UI](https://github.com/ollama-webui/ollama-webui)
-- [Ollamac - A native macOS app to interact with Ollama models](https://github.com/kevinhermawan/Ollamac)
+- [Ollamac](https://github.com/kevinhermawan/Ollamac)
 
 ### Terminal
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Typescript UI](https://github.com/ollama-interface/Ollama-Gui?tab=readme-ov-file)
 - [Minimalistic React UI for Ollama Models](https://github.com/richawo/minimal-llm-ui)
 - [Web UI](https://github.com/ollama-webui/ollama-webui)
+- [Ollamac - A native macOS app to interact with Ollama models](https://github.com/kevinhermawan/Ollamac)
 
 ### Terminal
 


### PR DESCRIPTION
Hi @jmorganca, I appreciate the time and effort you've put into developing Ollama—it's a fantastic tool! I noticed there isn't a native macOS application listed under community integrations, so I went ahead and created one called [Ollamac](https://github.com/kevinhermawan/Ollamac). I'm looking forward to hearing your thoughts on it! 😃

![Ollamac](https://github.com/jmorganca/ollama/assets/84965338/dcae2e9e-3f8c-4d19-9221-7567cf64ce93)