### PR TITLE
Added Ollama4j (Java library) to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [LiteLLM](https://github.com/BerriAI/litellm)
 - [OllamaSharp for .NET](https://github.com/awaescher/OllamaSharp)
 - [Ollama-rs for Rust](https://github.com/pepperoni21/ollama-rs)
+- [Ollama4j for Java](https://github.com/amithkoujalgi/ollama4j)
 - [ModelFusion Typescript Library](https://modelfusion.dev/integration/model-provider/ollama)
 
 ### Extensions & Plugins


### PR DESCRIPTION
Hi @jmorganca, thank you so much for your efforts in building and constantly updating such a cool piece of software. 
I really like Ollama and have been experimenting with it regularly. I also plan to integrate it into many more Java applications. 
I noticed there isn't a Java library listed under community integrations, that's why I felt the need to create a Java library for interacting with Ollama's REST APIs, and as a result, I've published Ollama4j as a package and I plan to constantly improve it. This way, others who work with Java can easily interact with the Ollama API. 

Thanks again, and keep up the great work!