### PR TITLE
Resume chunk download on UnexpectedEOF errors

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -161,6 +161,9 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *Regis
 					log.Printf("%s part %d attempt %d failed: %v, retrying", b.Digest[7:19], i, try, err)
 					continue
 				default:
+					if try > 0 {
+						log.Printf("%s part %d completed after %d retries", b.Digest[7:19], i, try)
+					}
 					return nil
 				}
 			}
@@ -202,7 +205,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 	defer resp.Body.Close()
 
 	n, err := io.Copy(w, io.TeeReader(resp.Body, b))
-	if err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		// rollback progress
 		b.Completed.Add(-n)
 		return err
@@ -213,7 +216,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 		return err
 	}
 
-	// return nil or context.Canceled
+	// return nil or context.Canceled or UnexpectedEOF (resumable)
 	return err
 }
 


### PR DESCRIPTION
If the chunk download is interrupted, resume from where we left off