### PR TITLE
Add Dart library to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama4j for Java](https://github.com/amithkoujalgi/ollama4j)
 - [ModelFusion Typescript Library](https://modelfusion.dev/integration/model-provider/ollama)
 - [OllamaKit for Swift](https://github.com/kevinhermawan/OllamaKit)
+- [Ollama for Dart](https://github.com/breitburg/dart-ollama)
 
 ### Extensions & Plugins
 


### PR DESCRIPTION
Good afternoon!

I have completed the first version of the Ollama library for Dart, making it possible to integrate Ollama into Flutter applications. I thought it would be nice to mention it in the readme file.

![](https://media.giphy.com/media/3oNMQtqpnse0dbFe06/giphy.gif)