### PR TITLE
Add Cheshire Cat to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Web UI](https://github.com/ollama-webui/ollama-webui)
 - [Ollamac](https://github.com/kevinhermawan/Ollamac)
 - [big-AGI](https://github.com/enricoros/big-agi/blob/main/docs/config-ollama.md)
+- [Cheshire Cat assistant framework](https://github.com/cheshire-cat-ai/core)
 
 ### Terminal
 


### PR DESCRIPTION
We have an Ollama adapter (subclassing langchain to make it both sync and async) and also created a [setup tutorial](https://cheshirecat.ai/local-models-with-ollama/)