### PR TITLE
fix: parse ggml model types

### DIFF
--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -31,7 +31,7 @@ func (c *containerGGUF) Name() string {
 	return "gguf"
 }
 
-func (c *containerGGUF) Decode(r io.Reader) (model, error) {
+func (c *containerGGUF) Decode(r io.Reader) error {
 	binary.Read(r, c.bo, &c.Version)
 
 	switch c.Version {
@@ -41,12 +41,7 @@ func (c *containerGGUF) Decode(r io.Reader) (model, error) {
 		binary.Read(r, c.bo, &c.V2)
 	}
 
-	model := newGGUFModel(c)
-	if err := model.Decode(r); err != nil {
-		return nil, err
-	}
-
-	return model, nil
+	return nil
 }
 
 const (


### PR DESCRIPTION
I'm kind of surprised this didn't come up earlier, noticed this while importing a less common ggml model type. Model parsing was returning `nil` for uncommon types which results in a nil pointer dereference. Fix this by moving model parsing up a level and try to decode as a llama model in the default case.