### PR TITLE
return failure details when unauthorized to push

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -1171,7 +1171,7 @@ func GetSHA256Digest(r io.Reader) (string, int64) {
 var errUnauthorized = fmt.Errorf("unauthorized")
 
 func makeRequestWithRetry(ctx context.Context, method string, requestURL *url.URL, headers http.Header, body io.ReadSeeker, regOpts *RegistryOptions) (*http.Response, error) {
-	var lastErr error
+	lastErr := errMaxRetriesExceeded
 	for try := 0; try < maxRetries; try++ {
 		resp, err := makeRequest(ctx, method, requestURL, headers, body, regOpts)
 		if err != nil {


### PR DESCRIPTION
Previous behavior:
Pushing to the default namespace or a namespace you don't have access to results in a vague error.
```
$ ollama push mario
retrieving manifest
Error: max retries exceeded
```

New behavior:
Pushing to the default namespace or a namespace you don't have access to results the reason for the error.
```
$ ollama push mario
retrieving manifest
Error: unable to push library/mario, make sure this namespace exists and you are authorized to push to it

$ ollama push bruxe/mario
retrieving manifest
Error: unable to push bruxe/mario, make sure this namespace exists and you are authorized to push to it
```

Resolves #1140 