### PR TITLE
fix potentially inaccurate error message

### DIFF
--- a/llm/llama.go
+++ b/llm/llama.go
@@ -226,7 +226,7 @@ type llama struct {
 }
 
 var (
-	errNvidiaSMI     = errors.New("warning: gpu support may not be enabled, check you have installed GPU drivers: nvidia-smi command failed")
+	errNvidiaSMI     = errors.New("warning: gpu support may not be enabled, check that you have installed GPU drivers: nvidia-smi command failed")
 	errAvailableVRAM = errors.New("not enough VRAM available, falling back to CPU only")
 )
 

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -226,7 +226,7 @@ type llama struct {
 }
 
 var (
-	errNvidiaSMI     = errors.New("nvidia-smi command failed")
+	errNvidiaSMI     = errors.New("warning: gpu support may not be enabled, check you have installed GPU drivers: nvidia-smi command failed")
 	errAvailableVRAM = errors.New("not enough VRAM available, falling back to CPU only")
 )
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -794,7 +794,7 @@ func Serve(ln net.Listener, allowOrigins []string) error {
 	if runtime.GOOS == "linux" {
 		// check compatibility to log warnings
 		if _, err := llm.CheckVRAM(); err != nil {
-			log.Printf("Warning: GPU support may not be enabled, check you have installed GPU drivers: %v", err)
+			log.Printf(err.Error())
 		}
 	}
 


### PR DESCRIPTION
In the case of not enough VRAM being available this log made it seem as though there was an issue with cuda libraries. Move the error details to only be returned if `nvidia-smi` is not available specifically. 