### PR TITLE
Fix issues sending incomplete body and add retry backoff for `ollama push`

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -53,8 +53,8 @@ type blobDownloadPart struct {
 
 const (
 	numDownloadParts          = 64
-	minDownloadPartSize int64 = 32 * 1000 * 1000
-	maxDownloadPartSize int64 = 256 * 1000 * 1000
+	minDownloadPartSize int64 = 100 * format.MegaByte
+	maxDownloadPartSize int64 = 1000 * format.MegaByte
 )
 
 func (p *blobDownloadPart) Name() string {
@@ -158,7 +158,9 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *Regis
 					// return immediately if the context is canceled or the device is out of space
 					return err
 				case err != nil:
-					log.Printf("%s part %d attempt %d failed: %v, retrying", b.Digest[7:19], i, try, err)
+					sleep := 200*time.Millisecond + time.Duration(try)*time.Second/4
+					log.Printf("%s part %d attempt %d failed: %v, retrying in %s", b.Digest[7:19], i, try, err, sleep)
+					time.Sleep(sleep)
 					continue
 				default:
 					if try > 0 {
@@ -304,7 +306,7 @@ type downloadOpts struct {
 	fn      func(api.ProgressResponse)
 }
 
-const maxRetries = 3
+const maxRetries = 10
 
 var errMaxRetriesExceeded = errors.New("max retries exceeded")
 

--- a/server/upload.go
+++ b/server/upload.go
@@ -196,6 +196,10 @@ func (b *blobUpload) Run(ctx context.Context, opts *RegistryOptions) {
 		resp, err := makeRequestWithRetry(ctx, http.MethodPut, requestURL, headers, nil, opts)
 		if err != nil {
 			b.err = err
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+
 			sleep := time.Second * time.Duration(math.Pow(2, float64(try)))
 			log.Printf("%s complete upload attempt %d failed: %v, retrying in %s", b.Digest[7:19], try, err, sleep)
 			time.Sleep(sleep)

--- a/server/upload.go
+++ b/server/upload.go
@@ -42,8 +42,8 @@ type blobUpload struct {
 
 const (
 	numUploadParts          = 64
-	minUploadPartSize int64 = 95 * 1000 * 1000
-	maxUploadPartSize int64 = 1000 * 1000 * 1000
+	minUploadPartSize int64 = 100 * format.MegaByte
+	maxUploadPartSize int64 = 1000 * format.MegaByte
 )
 
 func (b *blobUpload) Prepare(ctx context.Context, requestURL *url.URL, opts *RegistryOptions) error {
@@ -153,7 +153,9 @@ func (b *blobUpload) Run(ctx context.Context, opts *RegistryOptions) {
 					case errors.Is(err, errMaxRetriesExceeded):
 						return err
 					case err != nil:
-						log.Printf("%s part %d attempt %d failed: %v, retrying", b.Digest[7:19], part.N, try, err)
+						sleep := 200*time.Millisecond + time.Duration(try)*time.Second/4
+						log.Printf("%s part %d attempt %d failed: %v, retrying in %s", b.Digest[7:19], part.N, try, err, sleep)
+						time.Sleep(sleep)
 						continue
 					}
 

--- a/server/upload.go
+++ b/server/upload.go
@@ -155,6 +155,7 @@ func (b *blobUpload) Run(ctx context.Context, opts *RegistryOptions) {
 					case errors.Is(err, errMaxRetriesExceeded):
 						return err
 					case err != nil:
+						part.Reset()
 						sleep := time.Second * time.Duration(math.Pow(2, float64(try)))
 						log.Printf("%s part %d attempt %d failed: %v, retrying in %s", b.Digest[7:19], part.N, try, err, sleep)
 						time.Sleep(sleep)
@@ -258,6 +259,7 @@ func (b *blobUpload) uploadChunk(ctx context.Context, method string, requestURL 
 			case errors.Is(err, errMaxRetriesExceeded):
 				return err
 			case err != nil:
+				part.Reset()
 				sleep := time.Second * time.Duration(math.Pow(2, float64(try)))
 				log.Printf("%s part %d attempt %d failed: %v, retrying in %s", b.Digest[7:19], part.N, try, err, sleep)
 				time.Sleep(sleep)

--- a/server/upload.go
+++ b/server/upload.go
@@ -181,7 +181,7 @@ func (b *blobUpload) Run(ctx context.Context, opts *RegistryOptions) {
 		resp, err := makeRequestWithRetry(ctx, http.MethodPut, requestURL, headers, nil, opts)
 		if err != nil {
 			b.err = err
-			sleep := 200*time.Millisecond + time.Duration(try)*time.Second/4
+			sleep := time.Second * time.Duration(math.Pow(2, float64(try)))
 			log.Printf("%s complete upload attempt %d failed: %v, retrying in %s", b.Digest[7:19], try, err, sleep)
 			time.Sleep(sleep)
 			continue


### PR DESCRIPTION
Builds on #1184 

This change increases the upload chunk sizes and adds more graceful retry backoffs to fix issues transient network issues  when using `ollama push`.

It also fixes an issue where an incomplete body would be uploaded, requiring the need for a retry.