### PR TITLE
Add `user` to prompt template

### DIFF
--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -125,11 +125,11 @@ PARAMETER <parameter> <parametervalue>
 
 #### Template Variables
 
-| Variable        | Description                                                                                                  |
-| --------------- | ------------------------------------------------------------------------------------------------------------ |
-| `{{ .System }}` | The system prompt used to specify custom behavior, this must also be set in the Modelfile as an instruction. |
-| `{{ .Prompt }}` | The incoming prompt, this is not specified in the model file and will be set based on input.                 |
-| `{{ .First }}`  | A boolean value used to render specific template information for the first generation of a session.          |
+| Variable                          | Description                                                                                                  |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `{{ .System }}`                   | The system prompt used to specify custom behavior, this must also be set in the Modelfile as an instruction. |
+| `{{ .Prompt }}` or `{{ .User }}`  | The incoming prompt from the user, this is not specified in the model file and will be set based on input.   |
+| `{{ .First }}`                    | A boolean value used to render specific template information for the first generation of a session.          |
 
 ```modelfile
 TEMPLATE """

--- a/server/images.go
+++ b/server/images.go
@@ -50,7 +50,8 @@ type Model struct {
 
 type PromptVars struct {
 	System string
-	Prompt string
+	Prompt string // prompt and user are considered the same thing
+	User   string
 }
 
 func (m *Model) Prompt(vars *PromptVars) (string, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -321,6 +321,7 @@ func promptFromRequestParams(c *gin.Context, model *Model, req api.GenerateReque
 	p, err := model.Prompt(&PromptVars{
 		System: req.System,
 		Prompt: req.Prompt,
+		User:   req.Prompt,
 	})
 	if err != nil {
 		return "", err
@@ -340,6 +341,7 @@ func promptFromMessages(model *Model, messages []api.Message) (string, error) {
 		prompt.WriteString(p)
 
 		vars.Prompt = ""
+		vars.User = ""
 		vars.System = ""
 		return nil
 	}
@@ -364,6 +366,7 @@ func promptFromMessages(model *Model, messages []api.Message) (string, error) {
 			vars.System = m.Content
 		case "user":
 			vars.Prompt = m.Content
+			vars.User = m.Content
 		case "assistant":
 			prompt.WriteString(m.Content)
 		default:


### PR DESCRIPTION
With the upcoming `messages` API change the lack of symmetry between the `user` role and the `prompt` in the template is confusing. This change proposes adding `{{ .User }}` as an alternative to `{{ .Prompt }}` for the model template.

Here's an example:
```
FROM llama2
PARAMETER temperature 1
TEMPLATE """[INST] <<SYS>>{{ .System }}<</SYS>>

{{ .User }} [/INST]
"""
SYSTEM """
You are Mario from super mario bros, acting as an assistant.
"""
```