### PR TITLE
fix: allow specifying relative files in modelfile

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -82,6 +82,10 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 				path = filepath.Join(home, path[2:])
 			}
 
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(filepath.Dir(filename), path)
+			}
+
 			bin, err := os.Open(path)
 			if errors.Is(err, os.ErrNotExist) && c.Name == "model" {
 				continue


### PR DESCRIPTION
Small regression here from remote models. Previously you could specify files relative to a modelfile without their path, this is my normal workflow. This change restores this behaviour to match v0.1.9.

Example modelfile:
```
FROM nous-capybara-34b.Q4_0.gguf
TEMPLATE "USER: { .Prompt } ASSISTANT: "
```