### PR TITLE
docs: Add Oatmeal to terminal integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [ollama.nvim](https://github.com/nomnivore/ollama.nvim)
 - [ogpt.nvim](https://github.com/huynle/ogpt.nvim)
 - [gptel Emacs client](https://github.com/karthink/gptel)
+- [Oatmeal](https://github.com/dustinblackman/oatmeal)
 
 ### Libraries
 


### PR DESCRIPTION
## Overview

I love Ollama (amazing work on it!), it's what really got me in to trying LLMs. What was missing for my workflow was both a terminal application and Neovim plugin that actually *felt* like a chat app. [Oatmeal](https://github.com/dustinblackman/oatmeal) looks to deliver that with it's Ollama integration. 

Here's a fast demo to show it off using the Neovim editor integration. I hope it's something your users would find interesting as well.

![oatmeal-demo](https://github.com/dustinblackman/oatmeal/assets/5246169/9ee5e910-4eff-4deb-8065-aeab8bfe6b00)
