### PR TITLE
Make alt+backspace delete word

### DIFF
--- a/readline/readline.go
+++ b/readline/readline.go
@@ -145,6 +145,8 @@ func (i *Instance) Readline() (string, error) {
 				buf.MoveLeftWord()
 			case 'f':
 				buf.MoveRightWord()
+			case CharBackspace:
+				buf.DeleteWord()
 			case CharEscapeEx:
 				escex = true
 			}


### PR DESCRIPTION
In GNU Readline you can press alt+backspace to delete word. I'm used to this behavior and so it's jarring not to be able to do it. This commit adds the feature.