### PR TITLE
warn if running a ggml model file

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -119,6 +119,9 @@ type ShowResponse struct {
 	Parameters string `json:"parameters,omitempty"`
 	Template   string `json:"template,omitempty"`
 	System     string `json:"system,omitempty"`
+	// these fields are used to determine information about the model runtime
+	BaseModel string `json:"base_model,omitempty"`
+	ModelType string `json:"model_type,omitempty"`
 }
 
 type CopyRequest struct {


### PR DESCRIPTION
If the model a user is running will the use ggml runtime log a warning that prompts them to check for update to try and pull the gguf version of the model.

```
ollama run orca-mini
This model requires an update to work in future versions of Ollama. Check for update now? (y/n) y
pulling manifest
pulling 4de14feaabf8... 100% ▕██████▏(903 MB/903 MB)
pulling 8971eb8e89ce... 100% ▕██████▏(107 B/107 B)
pulling e7731c6d6962... 100% ▕██████▏(34 B/34 B)
pulling 905da7e7adc2... 100% ▕██████▏(76 B/76 B)
pulling 1bb164b05eb4... 100% ▕██████▏(460 B/460 B)
verifying sha256 digest
writing manifest
removing any unused layers
success
>>>
```