### PR TITLE
added llama_runner_timeout ModelFile parameter for longer timeouts

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -65,6 +65,7 @@ type Options struct {
 	MirostatEta      float32  `json:"mirostat_eta,omitempty"`
 	PenalizeNewline  bool     `json:"penalize_newline,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
+	LlamaRunnerTimeout int      `json:"llama_runner_timeout,omitempty"`
 }
 
 // Runner options which must be set when the model is loaded into memory

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -472,7 +472,7 @@ func newLlama(model string, adapters []string, runners []ModelRunner, numLayers 
 
 func waitForServer(llm *llama) error {
 	start := time.Now()
-	expiresAt := time.Now().Add(3 * time.Minute) // be generous with timeout, large models can take a while to load
+	expiresAt := time.Now().Add(time.Duration(llm.Options.LlamaRunnerTimeout) * time.Second) // be generous with timeout, large models can take a while to load
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/pbnjay/memory"
 
@@ -38,6 +39,9 @@ func New(workDir, model string, adapters []string, opts api.Options) (LLM, error
 	if err != nil {
 		return nil, err
 	}
+
+	//Default timeout when waiting on llama runner 
+	opts.LlamaRunnerTimeout = int((3 * time.Minute).Seconds());
 
 	if runtime.GOOS == "darwin" {
 		switch ggml.FileType() {


### PR DESCRIPTION
Allows the user to choose longer or shorter timeouts in the ModelFile for how long the server will wait for the llama runner. Created this patch in response to 'timed out waiting for llama runner to start' error. 

Defaults to the 3 minutes hard coded in the current main branch.