### PR TITLE
Add Amica to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollamac](https://github.com/kevinhermawan/Ollamac)
 - [big-AGI](https://github.com/enricoros/big-agi/blob/main/docs/config-ollama.md)
 - [Cheshire Cat assistant framework](https://github.com/cheshire-cat-ai/core)
+- [Amica](https://github.com/semperai/amica)
 
 ### Terminal
 


### PR DESCRIPTION
Hi!

This adds Amica (https://github.com/semperai/amica) to community integrations. 

Using ollama is very simple with Amica:

`settings -> chatbot -> chatbot backend -> select ollama`

Thanks for ollama it is a great project!