### PR TITLE
Correct MacOS Host Port in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,7 +23,7 @@ Ollama binds to 127.0.0.1 port 11434 by default. Change the bind address with th
 On macOS:
 
 ```bash
-OLLAMA_HOST=0.0.0.0:11435 ollama serve
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
 ```
 
 On Linux:


### PR DESCRIPTION
For some reason, the port for MacOS in this how-to was different then the one mentioned before and the one used after in the linux example. Skimming over this and copy pasting this as a Mac user, would result in the ollama program running on a different port and making it unreachable unless the port is changed in all other settings of all things using ollama.

If this was meant to show that you can use other ports, and wasnt just a typo, this would be a very bad way to do it. One single digit being different is nothing a normal person catches and then understands as "You can do this as well"