### PR TITLE
Fix Docker image not using GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as build
 
 ARG TARGETARCH
 ARG GOFLAGS="'-ldflags=-w -s'"
@@ -16,7 +16,7 @@ RUN /usr/local/go/bin/go generate ./... \
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 RUN apt-get update && apt-get install -y ca-certificates
-COPY --from=0 /go/src/github.com/jmorganca/ollama/ollama /bin/ollama
+COPY --from=build /go/src/github.com/jmorganca/ollama/ollama /bin/ollama
 EXPOSE 11434
 ENV OLLAMA_HOST 0.0.0.0
 ENTRYPOINT ["/bin/ollama"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV GOFLAGS=$GOFLAGS
 RUN /usr/local/go/bin/go generate ./... \
     && /usr/local/go/bin/go build .
 
-FROM ubuntu:22.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 RUN apt-get update && apt-get install -y ca-certificates
 COPY --from=0 /go/src/github.com/jmorganca/ollama/ollama /bin/ollama
 EXPOSE 11434


### PR DESCRIPTION
As it currently stands, the Docker image that gets built is seemingly unable to use the GPU despite the initial "build" stage of the Dockerfile ostensibly being built with CUDA support (i.e. built using the `nvidia/cuda` base image). As reported in https://github.com/jmorganca/ollama/issues/797, it seems that simply setting the second stage of the Dockerfile to use this same `nvidia/cuda` base image resolves the problem.