### PR TITLE
validate model tags on copy

### DIFF
--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -67,6 +67,20 @@ func ParseModelPath(name string) ModelPath {
 	return mp
 }
 
+var errModelPathInvalid = errors.New("invalid model path")
+
+func (mp ModelPath) Validate() error {
+	if mp.Repository == "" {
+		return fmt.Errorf("%w: model repository name is required", errModelPathInvalid)
+	}
+
+	if strings.Contains(mp.Tag, ":") {
+		return fmt.Errorf("%w: ':' (colon) is not allowed in tag names", errModelPathInvalid)
+	}
+
+	return nil
+}
+
 func (mp ModelPath) GetNamespaceRepository() string {
 	return fmt.Sprintf("%s/%s", mp.Namespace, mp.Repository)
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -416,8 +416,8 @@ func CreateModelHandler(c *gin.Context) {
 		return
 	}
 
-	if strings.Count(req.Name, ":") > 1 {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "':' (colon) is not allowed in tag names"})
+	if err := ParseModelPath(req.Name).Validate(); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -642,6 +642,11 @@ func CopyModelHandler(c *gin.Context) {
 
 	if req.Source == "" || req.Destination == "" {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "source add destination are required"})
+		return
+	}
+
+	if err := ParseModelPath(req.Destination).Validate(); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 


### PR DESCRIPTION
Validate model tags and name on copy/create.

Resolves #1247

Example errors:
```
ollama create mario:test:1 -f ~/models/mario/Modelfile
transferring model data
Error: invalid model path: ':' (colon) is not allowed in tag names

ollama create :test -f ~/models/mario/Modelfile
transferring model data
Error: invalid model path: model repository name is required

ollama cp brxce/nous-capybara brxce/capybara:1:2
Error: invalid model path: ':' (colon) is not allowed in tag names

ollama cp brxce/nous-capybara :1:2
Error: invalid model path: model repository name is required
```