### PR TITLE
Fix adapter loading from SHA hash

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -375,6 +375,15 @@ func CreateModel(ctx context.Context, name, modelFileDir string, commands []pars
 			layer.MediaType = mediatype
 			layers = append(layers, layer)
 		case "adapter":
+			if strings.HasPrefix(c.Args, "@") {
+				blobPath, err := GetBlobsPath(strings.TrimPrefix(c.Args, "@"))
+				if err != nil {
+					return err
+				}
+
+				c.Args = blobPath
+			}
+			
 			fn(api.ProgressResponse{Status: "creating adapter layer"})
 			bin, err := os.Open(realpath(modelFileDir, c.Args))
 			if err != nil {


### PR DESCRIPTION
When I tried to load an adapter from a local .bin file (by using `ollama create`), the command errored out with `Error: open /@sha256:ac5d2a80bc8bb4e9be08302373191c842a7edd3fcefd346d93e84941313b1c5a: no such file or directory`. I believe this is because the sha hash was misinterpreted as a filepath. I found where this is handled in `images.go` and saw that `model`s resolve hashes correctly but adapters do not. I don't have context on the past implementations of adapters, but maybe at one point the adapters were not hashed/versioned?

I hope this addresses the issue! One small thought is that this block of code might be able to be placed before the switch to reduce duplicated logic for `model`. Not sure if that'd have an impact on the other cases.