### PR TITLE
os specific ctrl-z

### DIFF
--- a/readline/readline.go
+++ b/readline/readline.go
@@ -192,14 +192,7 @@ func (i *Instance) Readline() (string, error) {
 		case CharCtrlW:
 			buf.DeleteWord()
 		case CharCtrlZ:
-			if err := UnsetRawMode(fd, termios); err != nil {
-				return "", err
-			}
-
-			syscall.Kill(0, syscall.SIGSTOP)
-
-			// on resume...
-			return "", nil
+			return i.handleCharCtrlZ(fd, termios)
 		case CharEnter:
 			output := buf.String()
 			if output != "" {

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -192,7 +192,7 @@ func (i *Instance) Readline() (string, error) {
 		case CharCtrlW:
 			buf.DeleteWord()
 		case CharCtrlZ:
-			return i.handleCharCtrlZ(fd, termios)
+			return handleCharCtrlZ(fd, termios)
 		case CharEnter:
 			output := buf.String()
 			if output != "" {

--- a/readline/readline_unix.go
+++ b/readline/readline_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package readline
+
+import (
+	"syscall"
+)
+
+func (i *Instance) handleCharCtrlZ(fd int, termios *Termios) (string, error) {
+	if err := UnsetRawMode(fd, termios); err != nil {
+		return "", err
+	}
+
+	syscall.Kill(0, syscall.SIGSTOP)
+
+	// on resume...
+	return "", nil
+}

--- a/readline/readline_unix.go
+++ b/readline/readline_unix.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 )
 
-func (i *Instance) handleCharCtrlZ(fd int, termios *Termios) (string, error) {
+func handleCharCtrlZ(fd int, termios *Termios) (string, error) {
 	if err := UnsetRawMode(fd, termios); err != nil {
 		return "", err
 	}

--- a/readline/readline_windows.go
+++ b/readline/readline_windows.go
@@ -1,0 +1,6 @@
+package readline
+
+func (i *Instance) handleCharCtrlZ(fd int, termios *Termios) (string, error) {
+	// not supported
+	return "", nil
+}

--- a/readline/readline_windows.go
+++ b/readline/readline_windows.go
@@ -1,6 +1,6 @@
 package readline
 
-func (i *Instance) handleCharCtrlZ(fd int, state *State) (string, error) {
+func handleCharCtrlZ(fd int, state *State) (string, error) {
 	// not supported
 	return "", nil
 }

--- a/readline/readline_windows.go
+++ b/readline/readline_windows.go
@@ -1,6 +1,6 @@
 package readline
 
-func (i *Instance) handleCharCtrlZ(fd int, termios *Termios) (string, error) {
+func (i *Instance) handleCharCtrlZ(fd int, state *State) (string, error) {
 	// not supported
 	return "", nil
 }


### PR DESCRIPTION
Add OS specific readline functions. Windows does not support these suspend system calls, so make ctrl-z a no-op on windows. This fixes development windows native builds.

resolves #1414