### PR TITLE
fix: encode full previous prompt in context

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -277,7 +277,7 @@ func GenerateHandler(c *gin.Context) {
 			}
 
 			if r.Done && !req.Raw {
-				embd, err := loaded.runner.Encode(c.Request.Context(), req.Prompt+generated.String())
+				embd, err := loaded.runner.Encode(c.Request.Context(), prompt+generated.String())
 				if err != nil {
 					ch <- gin.H{"error": err.Error()}
 					return


### PR DESCRIPTION
I believe this is a bug from the chat API changes, only the most recent request/response was added to the context history. It should be the full prompt after rebuilding the history. This shouldn't be in any released version.