### PR TITLE
fix: restore modelfile system in prompt template

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -64,6 +64,11 @@ func (m *Model) Prompt(p PromptVars) (string, error) {
 		return "", err
 	}
 
+	if p.System == "" {
+		// use the default system prompt for this model if one is not specified
+		p.System = m.System
+	}
+
 	vars := map[string]any{
 		"System":   p.System,
 		"Prompt":   p.Prompt,


### PR DESCRIPTION
In #1244 this line which sets the modelfile system variable in the template got removed. It must still be there to apply the system template from the modelfile. 