### PR TITLE
Fix Readme "Database -> MindsDB" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 ### Database
 
-- [MindsDB] (https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/ollama_handler/README.md)
+- [MindsDB](https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/ollama_handler/README.md)
   
 ### Package managers
 


### PR DESCRIPTION
This pull request fixes markdown ("MindsDB" link in Readme)