### PR TITLE
add API tests for list handler

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -2,12 +2,19 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jmorganca/ollama/api"
+	"github.com/jmorganca/ollama/parser"
 )
 
 func setupServer(t *testing.T) (*Server, error) {
@@ -40,6 +47,55 @@ func Test_Routes(t *testing.T) {
 				assert.Equal(t, `{"version":"0.0.0"}`, string(body))
 			},
 		},
+		{
+			Name:   "Tags Handler (no tags)",
+			Method: http.MethodGet,
+			Path:   "/api/tags",
+			Expected: func(t *testing.T, resp *http.Response) {
+				contentType := resp.Header.Get("Content-Type")
+				assert.Equal(t, contentType, "application/json; charset=utf-8")
+				body, err := io.ReadAll(resp.Body)
+				assert.Nil(t, err)
+
+				var modelList api.ListResponse
+
+				err = json.Unmarshal(body, &modelList)
+				assert.Nil(t, err)
+
+				assert.Equal(t, 0, len(modelList.Models))
+			},
+		},
+		{
+			Name:   "Tags Handler (yes tags)",
+			Method: http.MethodGet,
+			Path:   "/api/tags",
+			Setup: func(t *testing.T, req *http.Request) {
+				f, err := os.CreateTemp("", "ollama-modelfile")
+				assert.Nil(t, err)
+				defer os.RemoveAll(f.Name())
+
+				modelfile := strings.NewReader(fmt.Sprintf("FROM %s", f.Name()))
+				commands, err := parser.Parse(modelfile)
+				assert.Nil(t, err)
+				fn := func(resp api.ProgressResponse) {}
+				err = CreateModel(context.TODO(), "test", "", commands, fn)
+				assert.Nil(t, err)
+			},
+			Expected: func(t *testing.T, resp *http.Response) {
+				contentType := resp.Header.Get("Content-Type")
+				assert.Equal(t, contentType, "application/json; charset=utf-8")
+				body, err := io.ReadAll(resp.Body)
+				assert.Nil(t, err)
+
+				var modelList api.ListResponse
+
+				err = json.Unmarshal(body, &modelList)
+				assert.Nil(t, err)
+
+				assert.Equal(t, 1, len(modelList.Models))
+				assert.Equal(t, modelList.Models[0].Name, "test:latest")
+			},
+		},
 	}
 
 	s, err := setupServer(t)
@@ -49,6 +105,11 @@ func Test_Routes(t *testing.T) {
 
 	httpSrv := httptest.NewServer(router)
 	t.Cleanup(httpSrv.Close)
+
+	workDir, err := os.MkdirTemp("", "ollama-test")
+	assert.Nil(t, err)
+	defer os.RemoveAll(workDir)
+	os.Setenv("OLLAMA_MODELS", workDir)
 
 	for _, tc := range testCases {
 		u := httpSrv.URL + tc.Path


### PR DESCRIPTION
This change adds some tests for the `GET /api/list` endpoint. It includes a test that gets no models, and one that returns a single entry.