### PR TITLE
update required go version

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -23,11 +23,10 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/exp/slices"
 	"golang.org/x/term"
 
 	"github.com/jmorganca/ollama/api"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,10 +19,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmorganca/ollama
 
-go 1.20
+go 1.21
 
 require (
 	github.com/emirpasic/gods v1.18.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmorganca/ollama
 
-go 1.21
+go 1.20
 
 require (
 	github.com/emirpasic/gods v1.18.1


### PR DESCRIPTION
go 1.21 is required to build ollama, update the go.mod to reflect this

resolves #1515 