### PR TITLE
allow for starting llava queries with filepath

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -928,8 +928,18 @@ func generateInteractive(cmd *cobra.Command, opts generateOptions) error {
 			return nil
 		case strings.HasPrefix(line, "/"):
 			args := strings.Fields(line)
-			if multiModal && slices.Contains(extractFileNames(line), args[0]) {
-				// this is a file path, not a command, add it to the prompt
+			isFile := false
+
+			if multiModal {
+				for _, f := range extractFileNames(line) {
+					if strings.HasPrefix(f, args[0]) {
+						isFile = true
+						break
+					}
+				}
+			}
+
+			if isFile {
 				prompt += line
 			} else {
 				fmt.Printf("Unknown command '%s'. Type /? for help\n", args[0])


### PR DESCRIPTION
- shared cmd file pattern regex
- do not error when multimodal has starting file

There was a bug that a multimodal query starting with an unescaped file path resulted in an "Unknown command" error.

This change allows for multimodal models to have queries starting with the filepath.

```
$ ollama run llava
>>> /test
Unknown command '/test'. Type /? for help
>>> /Users/bruce/Downloads/Ollama_christmas_background.png what is this
Added image '/Users/bruce/Downloads/Ollama_christmas_background.png'
 This is a cartoon of cats, and it appears to be an illustration or drawing of the animals. The scene depicts them gathered around a Christmas tree. In total, there are nine cats in various positions, with some standing close together while others are more spread out. One cat can be seen sitting underneath the 
tree, perhaps enjoying the holiday festivities. The overall atmosphere seems to be joyful and playful as these cats interact and pose around their Christmas tree setting.

$ ollama run llama2
>>> /Users/bruce/Downloads/Ollama_christmas_background.png what is this
Unknown command '/Users/bruce/Downloads/Ollama_christmas_background.png'. Type /? for help
```

resolves #1511