### PR TITLE
add magic header for unit tests

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -41,6 +41,7 @@ func Test_Routes(t *testing.T) {
 		_, err = f.Write([]byte("GGUF"))
 		assert.Nil(t, err)
 		_, err = f.Write([]byte{0x2, 0})
+		assert.Nil(t, err)
 
 		return f.Name()
 	}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -33,31 +32,27 @@ func Test_Routes(t *testing.T) {
 		Setup    func(t *testing.T, req *http.Request)
 		Expected func(t *testing.T, resp *http.Response)
 	}
-	var tempModelFile string
 
 	createTestFile := func(t *testing.T, name string) string {
-		data := make([]byte, 6)
-
-		copy(data[0:4], []byte("GGUF"))
-		copy(data[4:6], []byte{0x2, 0})
-
-		f, err := os.CreateTemp("", name)
+		f, err := os.CreateTemp(t.TempDir(), name)
 		assert.Nil(t, err)
-		_, err = f.Write(data)
+		defer f.Close()
+
+		_, err = f.Write([]byte("GGUF"))
 		assert.Nil(t, err)
+		_, err = f.Write([]byte{0x2, 0})
 
 		return f.Name()
 	}
 
 	createTestModel := func(t *testing.T, name string) {
 		fname := createTestFile(t, "ollama-model")
-		defer os.RemoveAll(fname)
 
 		modelfile := strings.NewReader(fmt.Sprintf("FROM %s", fname))
 		commands, err := parser.Parse(modelfile)
 		assert.Nil(t, err)
 		fn := func(resp api.ProgressResponse) {
-			log.Printf("Status: %s", resp.Status)
+			t.Logf("Status: %s", resp.Status)
 		}
 		err = CreateModel(context.TODO(), name, "", commands, fn)
 		assert.Nil(t, err)
@@ -122,9 +117,9 @@ func Test_Routes(t *testing.T) {
 			Method: http.MethodPost,
 			Path:   "/api/create",
 			Setup: func(t *testing.T, req *http.Request) {
-				f, err := os.CreateTemp("", "ollama-model")
+				f, err := os.CreateTemp(t.TempDir(), "ollama-model")
 				assert.Nil(t, err)
-				tempModelFile = f.Name()
+				defer f.Close()
 
 				stream := false
 				createReq := api.CreateRequest{
@@ -138,8 +133,6 @@ func Test_Routes(t *testing.T) {
 				req.Body = io.NopCloser(bytes.NewReader(jsonData))
 			},
 			Expected: func(t *testing.T, resp *http.Response) {
-				os.RemoveAll(tempModelFile)
-
 				contentType := resp.Header.Get("Content-Type")
 				assert.Equal(t, "application/json", contentType)
 				_, err := io.ReadAll(resp.Body)
@@ -188,7 +181,7 @@ func Test_Routes(t *testing.T) {
 	os.Setenv("OLLAMA_MODELS", workDir)
 
 	for _, tc := range testCases {
-		log.Printf("Running Test: [%s]", tc.Name)
+		t.Logf("Running Test: [%s]", tc.Name)
 		u := httpSrv.URL + tc.Path
 		req, err := http.NewRequestWithContext(context.TODO(), tc.Method, u, nil)
 		assert.Nil(t, err)


### PR DESCRIPTION
This change adds in the magic GGUF header for the temporary model image layer.