### PR TITLE
RFC - initial foundation for distributed integration test rigging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,4 @@ dist
 llm/llama.cpp
 .env
 .cache
-test_data
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ggml-metal.metal
 *.exe
 .idea
 test_data
+coverage

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -79,6 +79,7 @@ COPY --from=cuda-build-amd64 /go/src/github.com/jmorganca/ollama/llm/llama.cpp/b
 COPY --from=rocm-5-build-amd64 /go/src/github.com/jmorganca/ollama/llm/llama.cpp/build/linux/ llm/llama.cpp/build/linux/
 COPY --from=rocm-6-build-amd64 /go/src/github.com/jmorganca/ollama/llm/llama.cpp/build/linux/ llm/llama.cpp/build/linux/
 RUN go build .
+RUN go build -cover -o ollama-cov .
 
 FROM --platform=linux/arm64 cpu-build-arm64 AS build-arm64
 ENV CGO_ENABLED 1
@@ -89,5 +90,6 @@ WORKDIR /go/src/github.com/jmorganca/ollama
 COPY . .
 COPY --from=cuda-build-arm64 /go/src/github.com/jmorganca/ollama/llm/llama.cpp/build/linux/ llm/llama.cpp/build/linux/
 RUN go build .
+RUN go build -cover -o ollama-cov .
 
 FROM build-$TARGETARCH

--- a/scripts/binaries.py
+++ b/scripts/binaries.py
@@ -1,0 +1,67 @@
+import hashlib
+import logging
+import os
+
+BUF_SIZE = 65536
+
+class Binaries:
+    def __init__(self, distDir):
+        self.distDir = distDir
+        self.log = logging.getLogger(__name__)
+        # Check if distDir exists and is a directory
+        if not os.path.isdir(distDir):
+            raise ValueError("distDir must be a valid directory")
+
+        # Check for files in distDir
+        fileList = os.listdir(distDir)
+        if len(fileList) == 0:
+            raise ValueError(distDir + " is empty - did you forget to build first?")
+
+        # Split the filenames in distDir
+        self.binaries = {}
+        for filename in fileList:
+            self.log.debug("processing "+ filename)
+            parts = filename.split("-")
+            hash = ""
+            with open(os.path.join(distDir, filename), 'rb') as f:
+                hasher = hashlib.md5()
+                while True:
+                    data = f.read(BUF_SIZE)
+                    if not data:
+                        break
+                    hasher.update(data)
+                hash = hasher.hexdigest().lower()
+                
+            cpu, cov = False, False
+            if len(parts) == 1 and parts[0] == "ollama":
+                # most likely the multi-arch darwin binary
+                self.binaries[("darwin", "amd64", False, False)] = (filename, hash)
+                self.binaries[("darwin", "arm64", False, False)] = (filename, hash)
+                continue
+            elif len(parts) < 3:
+                self.log.debug("skipping " + filename)
+                continue
+            elif len(parts) == 3:
+                _, OS, arch = parts[0], parts[1], parts[2]
+                arch  = arch.split(".")[0]
+            else:
+                _, OS, arch, rest = parts[0], parts[1], parts[2], parts[3]
+                # Parse the CPU and coverage info
+                if rest.startswith("cpu"):
+                    cpu = True
+                if rest.startswith("cov"):
+                    cov = True
+            self.binaries[(OS, arch, cpu, cov)] = (filename, hash)
+
+    def getBinary(self, OS, arch, cpu, cov):
+        if (OS, arch, cpu, cov) not in self.binaries:
+            print(self.binaries.keys())
+            print(OS, arch, cpu, cov)
+            raise ValueError("requested binary not present")
+        return self.binaries[(OS, arch, cpu, cov)]
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    b = Binaries("./dist")
+    logging.info("Discovered binaries" + str(b.binaries))
+

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Wrapper script to build all our platforms and store the results in ./dist
+if [ "$(uname)" != "Darwin" ]; then
+    echo "ERROR: This script is only intended to run from MacOS at present"
+    exit 1
+fi
+if [ $# -ne 1 ]; then
+    echo "ERROR: you must specify a windows git remote name as an argument"
+    exit 1
+fi
+
+# Make sure the tree isn't dirty, as the remote build script needs all changes committed
+if [[ $(git diff --stat) != '' ]]; then
+    echo "ERROR: Your tree is not clean.  Please git add and commit all local changes first"
+    exit 1
+fi
+
+
+REMOTE_NAME=$1
+DARWIN_LOG=./dist/darwin-build.log
+LINUX_LOG=./dist/linux-build.log
+WINDOWS_LOG=./dist/windows-build.log
+ret="0"
+mkdir -p ./dist
+
+./scripts/build_linux.sh &> ${LINUX_LOG} &
+LINUX_PID=$!
+echo "Linux build started.   Watch log with 'tail -F ${LINUX_LOG}'"
+
+./scripts/build_remote.py ${REMOTE_NAME} &> ${WINDOWS_LOG} &
+WINDOWS_PID=$!
+echo "Windows build started. Watch log with 'tail -F ${WINDOWS_LOG}'"
+
+./scripts/build_darwin.sh &> ${DARWIN_LOG} &
+DARWIN_PID=$!
+echo "Darwin build started.  Watch log with 'tail -F ${DARWIN_LOG}'"
+
+echo "Waiting for builds to finish..."
+echo ""
+
+wait ${DARWIN_PID}
+if [ $? -ne 0 ]; then
+    echo "Darwin build failed $? - run 'tail ${DARWIN_LOG}' for details"
+    ret="1"
+else
+    echo "Darwin build completed."
+fi
+wait ${WINDOWS_PID}
+if [ $? -ne 0 ]; then
+    echo "Windows build failed $? - run 'tail ${WINDOWS_LOG}' for details"
+    ret="1"
+else
+    echo "Windows build completed."
+fi
+wait ${LINUX_PID}
+if [ $? -ne 0 ]; then
+    echo "Linux build failed $? - run 'tail ${LINUX_LOG}' for details"
+    ret="1"
+else
+    echo "Linux build completed."
+fi
+exit "${ret}"

--- a/scripts/build_darwin.sh
+++ b/scripts/build_darwin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -e
 
 export VERSION=${VERSION:-0.0.0}
 export GOFLAGS="'-ldflags=-w -s \"-X=github.com/jmorganca/ollama/version.Version=$VERSION\" \"-X=github.com/jmorganca/ollama/server.mode=release\"'"
@@ -11,21 +11,36 @@ for TARGETARCH in arm64 amd64; do
     rm -rf llm/llama.cpp/build
     GOOS=darwin GOARCH=$TARGETARCH go generate ./...
     CGO_ENABLED=1 GOOS=darwin GOARCH=$TARGETARCH go build -o dist/ollama-darwin-$TARGETARCH
+    CGO_ENABLED=1 GOOS=darwin GOARCH=$TARGETARCH go build -cover -o dist/ollama-darwin-$TARGETARCH-cov
 done
 
-lipo -create -output dist/ollama dist/ollama-darwin-*
-rm -f dist/ollama-darwin-*
-codesign --deep --force --options=runtime --sign "$APPLE_IDENTITY" --timestamp dist/ollama
+lipo -create -output dist/ollama dist/ollama-darwin-arm64 dist/ollama-darwin-amd64
+rm -f dist/ollama-darwin-arm64 dist/ollama-darwin-amd64
+if [ -n "$APPLE_IDENTITY" ]; then
+    codesign --deep --force --options=runtime --sign "$APPLE_IDENTITY" --timestamp dist/ollama
+else
+    echo "Skipping code signing - set APPLE_IDENTITY"
+fi
 chmod +x dist/ollama
 
-# build and sign the mac app
+# build and optionally sign the mac app
 npm install --prefix app
-npm run --prefix app make:sign
+if [ -n "$APPLE_IDENTITY" ]; then
+    npm run --prefix app make:sign
+else 
+    npm run --prefix app make
+fi
 cp app/out/make/zip/darwin/universal/Ollama-darwin-universal-$VERSION.zip dist/Ollama-darwin.zip
 
 # sign the binary and rename it
-codesign -f --timestamp -s "$APPLE_IDENTITY" --identifier ai.ollama.ollama --options=runtime dist/ollama
+if [ -n "$APPLE_IDENTITY" ]; then
+    codesign -f --timestamp -s "$APPLE_IDENTITY" --identifier ai.ollama.ollama --options=runtime dist/ollama
+else
+    echo "WARNING: Skipping code signing - set APPLE_IDENTITY"
+fi
 ditto -c -k --keepParent dist/ollama dist/temp.zip
-xcrun notarytool submit dist/temp.zip --wait --timeout 10m --apple-id $APPLE_ID --password $APPLE_PASSWORD --team-id $APPLE_TEAM_ID
+if [ -n "$APPLE_IDENTITY" ]; then
+    xcrun notarytool submit dist/temp.zip --wait --timeout 10m --apple-id $APPLE_ID --password $APPLE_PASSWORD --team-id $APPLE_TEAM_ID
+fi
 mv dist/ollama dist/ollama-darwin
 rm -f dist/temp.zip

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -12,5 +12,6 @@ for TARGETARCH in ${BUILD_ARCH}; do
     docker build --platform=linux/$TARGETARCH --build-arg=GOFLAGS --build-arg=CGO_CFLAGS --build-arg=OLLAMA_CUSTOM_CPU_DEFS -f Dockerfile.build -t builder:$TARGETARCH .
     docker create --platform linux/$TARGETARCH --name builder-$TARGETARCH builder:$TARGETARCH
     docker cp builder-$TARGETARCH:/go/src/github.com/jmorganca/ollama/ollama ./dist/ollama-linux-$TARGETARCH
+    docker cp builder-$TARGETARCH:/go/src/github.com/jmorganca/ollama/ollama-cov ./dist/ollama-linux-$TARGETARCH-cov
     docker rm builder-$TARGETARCH
 done

--- a/scripts/machine.py
+++ b/scripts/machine.py
@@ -1,0 +1,224 @@
+import logging
+import os
+import select
+import subprocess
+import threading
+from paramiko import SSHClient, SFTPClient, SSHConfig
+import time
+import sys
+import random
+import pathlib
+
+# Ollama test Machine
+class Machine:
+    def __init__(self, sshClient, hostname, port=None, variant=""):
+        self.log = logging.getLogger(__name__)
+        self.remoteDir = "." # TODO configurable and OS aware?
+        self.remoteCoverDir = "." # TODO probably someplace better
+        self.coverDir = "./coverage/"
+        self.ssh = sshClient   
+        self.hostname = hostname
+        self.running = False
+        self.remotePort = str(random.randint(1024, 65535))
+        self.localPort = str(random.randint(1024, 65535))
+        self.newline = '\n'
+        self.envPrefix = "export "
+        self.sshPort = port
+        self.variant = variant
+
+        self.ssh.load_system_host_keys()
+        if self.hostname.find("@") >= 0:
+            user, hostname = hostname.split("@")
+            if self.sshPort:
+                self.ssh.connect(hostname, username=user, port=self.sshPort)
+            else:
+                self.ssh.connect(hostname, username=user)
+            self.coverDir += hostname
+        elif self.sshPort:
+            self.ssh.connect(hostname, port=self.sshPort)
+            self.coverDir += hostname
+        else:
+            self.ssh.connect(hostname)
+            self.coverDir += hostname
+        self.transport = self.ssh.get_transport()
+        self.channel = None
+
+    # Figure out what type of system it is
+    # windows vs. linux vs. mac
+    # what type of self.gpu 
+    def assesMachine(self):
+        self.os=""
+        self.arch=""
+        self.gpu=""
+        # Try to determine what kind of remote system we're working with
+        try:
+            # Try for linux/mac first
+            inp, outp, errp = self.ssh.exec_command('uname -a')
+            if outp.channel.recv_exit_status() != 0:
+                raise Exception("uname failed")
+            inp.close()
+            data = outp.read()
+            errp.close()
+            uname = str(data).lower()
+            if uname.find("darwin") >= 0:
+                self.os="darwin"
+            elif uname.find("linux") >= 0:
+                self.os="linux"
+                inp, outp, errp = self.ssh.exec_command('lspci | grep VGA')
+                inp.close()
+                data = outp.read()
+                errp.close()
+                gpus = str(data).lower()
+                if gpus.find("nvidia") >= 0:
+                    self.gpu="cuda"
+                elif gpus.find("amd") >= 0 or gpus.find("advanced micro devices") >= 0:
+                    self.gpu="rocm"
+            else:
+                raise("Unrecognized unix-like self.os " + uname)
+            if uname.find("arm64") >= 0:
+                self.arch="arm64"
+            elif uname.find("x86_64") >= 0:
+                self.arch="amd64"
+            else:
+                raise("Unrecognized unix-like self.arch " + uname)
+            if self.os == "darwin" and self.arch == "arm64":
+                self.gpu="metal"
+                
+        except:
+            # fallback to windows detection
+            inp, outp, errp = self.ssh.exec_command('Get-WmiObject Win32_ComputerSystem | select SystemType')
+            inp.close()
+            data = outp.read()
+            errp.close()
+            sysType = str(data).lower()
+            self.os="windows"
+            self.newline = '\r\n'
+            self.envPrefix = '$env:'
+            # BINARY_EXE=".exe"
+            if sysType.find("x64") >= 0:
+                self.arch="amd64"
+            elif sysType.find("arm") >= 0:
+                self.arch="arm64"
+            else:
+                raise("Unrecognized windows self.arch " + sysType)
+            inp, outp, errp = self.ssh.exec_command('Get-WmiObject Win32_VideoController | select Name')
+            inp.close()
+            data = outp.read()
+            errp.close()
+            gpus = str(data).lower()
+            if gpus.find("nvidia") >= 0:
+                self.gpu="cuda"
+            elif gpus.find("amd") >= 0 or gpus.find("advanced micro devices") >= 0:
+                self.gpu="rocm"
+        self.log.info("Detected remote system as %s %s %s", self.os, self.arch, self.gpu)
+
+
+    # Based on assessed machine type, copy over the applicable binary
+    def copyBinary(self, binaries, cpu, cov):
+        filename, checksum = binaries.getBinary(self.os, self.arch, cpu, cov)
+        self.remoteBinary = os.path.join(self.remoteDir, filename)
+        self.log.info("checking remote system for matching checksum")
+        if self.os == "windows":
+            inp, outp, errp = self.ssh.exec_command('(get-filehash -algorithm md5 ' + self.remoteBinary + ').hash')
+            inp.close()
+            data = outp.read()
+            errp.close()
+            hash = data.decode('ascii').lower().strip()
+        else:
+            inp, outp, errp = self.ssh.exec_command('md5sum ' + self.remoteBinary + ' | cut -f1 -d\ ')
+            inp.close()
+            data = outp.read()
+            errp.close()
+            hash = data.decode('ascii').lower().strip()
+        if checksum != hash:
+            self.log.info("{0} does not contain the correct binary - uploading {1}".format(self.hostname, self.remoteBinary))
+            binaryPath = os.path.join(binaries.distDir, filename)
+            with SFTPClient.from_transport(self.transport) as sftp:
+                self.log.info("copying {0} to {1}".format(self.remoteBinary, self.hostname))
+                sftp.put(binaryPath, self.remoteBinary)
+                sftp.chmod(self.remoteBinary, 0o755)
+        else:
+            self.log.info("{0} already up to date on {1}".format(self.remoteBinary, self.hostname))
+
+    def startServer(self):
+        self.serverSession = self.transport.open_session()
+        self.thread = threading.Thread(target=self.runner)
+        self.running = True
+        self.thread.start()
+
+    def runner(self):
+        self.serverSession.setblocking(0)
+        self.serverSession.get_pty()
+        self.serverSession.invoke_shell()
+        self.serverSession.send(self.envPrefix + "GOCOVERDIR=\"" + self.remoteCoverDir + "\"" + self.newline)
+        self.serverSession.send(self.envPrefix + "OLLAMA_HOST=\"127.0.0.1:" + self.remotePort + "\"" + self.newline)
+        if self.variant != "":
+            self.serverSession.send(self.envPrefix + "OLLAMA_LLM_LIBRARY=\"" + self.variant + "\"" + self.newline)
+        self.serverSession.send(self.remoteBinary + " serve" + self.newline)
+        print("\n")
+        while self.running:
+            if self.serverSession.recv_ready():
+                data = self.serverSession.recv(512)
+                # TODO Write this to some sort of log file so it's not gumming up the console
+                sys.stdout.buffer.write(data)
+                sys.stdout.flush()
+            time.sleep(0.001)
+        self.log.info("closing server session to " + self.hostname)
+
+    # TODO - add interactive option too so we can exercise the REPL
+    def runClientOneShot(self, cmd_args):
+        cmd = self.remoteBinary + " " + cmd_args
+        self.log.info("Starting client")
+        env_prefix = self.envPrefix + "GOCOVERDIR=\"" + self.remoteCoverDir + "\"; "
+        env_prefix += self.envPrefix + "OLLAMA_HOST=\"127.0.0.1:" + self.remotePort + "\"; "
+        inp, outp, errp = self.ssh.exec_command(env_prefix + self.remoteBinary + ' ' + cmd_args)
+        inp.close() # TODO consider interactive support for more complex test scenarios
+        if outp.channel.recv_exit_status() != 0:
+            err = errp.read()
+            self.log.error(err.decode('ascii'))
+            raise Exception("{0} {1} on {2} failed".format(self.remoteBinary, cmd_args, self.hostname))
+        data = outp.read()
+        errp.close()
+        outp.close()
+        return data
+
+    def stopServer(self):
+        self.log.info("signaling shutdown of remote server")
+        self.running = False
+        self.serverSession.send('\x03') # ^C
+        time.sleep(3) # TODO more deterministic way to make sure coverage data is written out...
+        if self.channel:
+            self.log.info("closing channel")
+            self.channel.close()
+        self.log.info("joining")
+        self.thread.join()
+        covDir = pathlib.Path(self.coverDir)
+        if not covDir.exists():
+            covDir.mkdir(parents=True)
+        with SFTPClient.from_transport(self.transport) as sftp:
+            self.log.info("copying coverage from {0}".format(self.hostname))
+            for filename in sftp.listdir(self.remoteCoverDir):
+                if not filename.startswith("cov"):
+                    continue
+                sftp.get(os.path.join(self.remoteCoverDir, filename), os.path.join(self.coverDir, filename))
+
+        self.log.info("done")
+
+
+# if __name__ == '__main__':
+#     logging.basicConfig(level=logging.INFO)
+#     ssh = SSHClient()
+#     ssh.load_system_host_keys()
+#     m = Machine(ssh, "daniel@desktop-puni632")
+#     m.assesMachine()
+    
+
+# b = Binaries("./dist")
+# logging.info("Binaries" + str(b.binaries))
+# sys.exit(0)
+# m.copyBinary()
+# m.startServer()
+# time.sleep(2)
+# m.runClient("run orca-mini hello")
+# time.sleep(30)
+# m.stopServer()

--- a/scripts/regression_suite.py
+++ b/scripts/regression_suite.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+import time
+from binaries import Binaries
+from machine import Machine
+from paramiko import SSHClient
+import logging
+import yaml
+import os
+
+# Very rudimentary regression suite to execute hello world remotely and gather some results
+# TODO - this should be revampted into some test framework to be able to parallelize
+
+TEST_CONFIG="./test-systems.yaml"
+
+if __name__ == '__main__':
+    if not os.path.exists(TEST_CONFIG):
+        print("ERROR: you must create a test config file")
+        sys.exit(1)
+    with open(TEST_CONFIG) as cfgFile:
+        cfg = yaml.safe_load(cfgFile)
+
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger(__name__)
+
+    # Dumb algorithm for now, just serial
+    for lib in cfg:
+        # print("Testing type " + lib)
+        for t in cfg[lib]:
+            tgt = cfg[lib][t]
+            variant = tgt.get("variant", "")
+            port = tgt.get("port")
+            conn = tgt.get("connect", t)
+            log.info("Testing on " + t + " " + variant + " connecting via " + conn)
+      
+            ssh = SSHClient()
+            ssh.load_system_host_keys()
+            m = Machine(ssh, conn, port=port, variant=variant)
+            m.assesMachine()
+            b = Binaries("./dist")
+            m.copyBinary(b, False, True)
+            m.startServer()
+            time.sleep(5)
+            data = m.runClientOneShot("run orca-mini hello")
+            # TODO - we could verify the data has something we expect...
+            sys.stdout.buffer.write(data)
+            sys.stdout.flush()
+            m.stopServer()
+
+    # # Now aggregate the coverage results and pop up a report
+    # BUSTED - 
+    # go tool cover -html ./out.txt
+    # cover: inconsistent NumStmt: changed from 4 to 3
+    # log.info("Generating coverage report...")
+    # subprocess.run("go tool covdata textfmt -i=coverage -o coverage/cov.txt", shell=True, check=True)
+    # subprocess.run("go tool cover -html ./coverage/cov.txt", shell=True, check=True)
+
+
+# After running tests across multiple systems view the coverage results with:
+#
+# go tool covdata textfmt -i=coverage -o coverage/cov.txt
+# go tool cover -html ./coverage/cov.txt 

--- a/server/llm_image_test.go
+++ b/server/llm_image_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jmorganca/ollama/api"
 	"github.com/jmorganca/ollama/llm"
@@ -34,7 +33,8 @@ func TestIntegrationMultimodal(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 	require.NoError(t, llm.Init(workDir))
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	// Note: this takes significantly longer on CPU than other mini tests (~300s)
+	ctx, cancel := context.WithTimeout(context.Background(), ContextTimeout)
 	defer cancel()
 	opts := api.DefaultOptions()
 	opts.Seed = 42

--- a/server/llm_test.go
+++ b/server/llm_test.go
@@ -40,6 +40,9 @@ var (
 		"once upon a time",
 		"united states thanksgiving",
 	}
+	// TODO - consider adjusting this based on CPU vs. GPU
+	//        For now, set to accomodate CPU based running
+	ContextTimeout = time.Second * 420
 )
 
 func TestIntegrationSimpleOrcaMini(t *testing.T) {
@@ -48,7 +51,7 @@ func TestIntegrationSimpleOrcaMini(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 	require.NoError(t, llm.Init(workDir))
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	ctx, cancel := context.WithTimeout(context.Background(), ContextTimeout)
 	defer cancel()
 	opts := api.DefaultOptions()
 	opts.Seed = 42
@@ -72,7 +75,7 @@ func TestIntegrationConcurrentPredictOrcaMini(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 	require.NoError(t, llm.Init(workDir))
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	ctx, cancel := context.WithTimeout(context.Background(), ContextTimeout)
 	defer cancel()
 	opts := api.DefaultOptions()
 	opts.Seed = 42
@@ -98,7 +101,7 @@ func TestIntegrationConcurrentRunnersOrcaMini(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 	require.NoError(t, llm.Init(workDir))
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	ctx, cancel := context.WithTimeout(context.Background(), ContextTimeout)
 	defer cancel()
 	opts := api.DefaultOptions()
 	opts.Seed = 42

--- a/test-systems.yaml
+++ b/test-systems.yaml
@@ -1,0 +1,46 @@
+# All systems must have ssh access enabled
+# Windows systems must have powershell configured as the primary/default shell for ssh
+
+
+# Always has 3 top level keys: cpu, cuda, and rocm
+  # Next level is the name of the node (assumed to be hostname)
+    # Next level has optional settings
+    # connect: Use alterate connection string instead of just hostname
+    # port: Use alternate ssh port to connect to remote system
+    # variant: if set, we'll force that specific variant when testing 
+
+# DO NOT MERGE AS IS
+
+cpu:
+  # Use Orac to test the various CPU builds
+  orac_cpu:
+    connect: dhiltgen@orac
+    variant: cpu
+  orac_avx:
+    connect: dhiltgen@orac
+    variant: cpu_avx
+  orac_avx2:
+    connect: dhiltgen@orac
+    variant: cpu_avx2
+  windows-pa_cpu:
+    connect: daniel@desktop-puni632
+    variant: cpu
+  windows-pa_avx:
+    connect: daniel@desktop-puni632
+    variant: cpu_avx
+  windows-pa_avx2:
+    connect: daniel@desktop-puni632
+    variant: cpu_avx2
+
+cuda:
+  # ssh tunnel to a NVIDIA GeForce GTX 1650 CC 7.5
+  # daniel-laptop:
+  #   connect: daniel@localhost
+  #   port: 2022
+  windows-pa:
+    connect: daniel@desktop-puni632
+
+rocm:
+  orac:
+    connect: dhiltgen@orac
+    variant: rocm_v6


### PR DESCRIPTION
This adds some new script rigging that may help flesh out integration tests.

It doesn't actually do any interesting testing yet (just a [hello world](https://github.com/jmorganca/ollama/pull/1569/files#diff-aea44eb9fc093044f1591164d21a64fef7e13e504088f1599e4685f9835ddb4d)), but demonstrates how this could work and be layered into PyTest or similar frameworks.

At present, it requires you're running on a mac.
First [build all target architectures](https://github.com/jmorganca/ollama/pull/1569/files#diff-ad855df3d2b5ffdf734facd7dbd1c5d4dd1da6fcd50110f86015e64ef9c9d88e):
```
./scripts/build_all.sh <some-windows-remote-name>
```

This will produce both regular and coverage instrumented binaries in `./dist/`

There's a yaml config file to drive what the remote target systems are: [test-system.yaml](https://github.com/jmorganca/ollama/pull/1569/files#diff-e4638e57348bd44ab998a6ec8e425553e91e72712b8da5dafaa2506ac8633408)

Then you can run a 
```
python3 ./scripts/regression_suite.py
```

which will figure out the remote target system OS/arch, and then copy over the required binary (if not already present) and then run the server with coverage, and then run a hello world client, then shutdown the server, and gather coverage data.  You can use the experimental variant env var to force certain llm libraries to increase coverage.


I've confirmed it works on linux and windows.   

Notable gaps:
* Still need to add a docker/container based test mechanism
* Serial running is lame, but I just wanted to prove out the concept - it should really use some test framework to parallelize the run across all the systems, and be smart about hostnames so it doesn't hit the same host multiple times in parallel.
* WSL on windows needs support
* It should work on remote mac systems, but I haven't tested it yet.