### PR TITLE
adds ooo to Community Integrations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [gptel Emacs client](https://github.com/karthink/gptel)
 - [Oatmeal](https://github.com/dustinblackman/oatmeal)
 - [cmdh](https://github.com/pgibler/cmdh)
+- [ooo](https://github.com/npahlfer/ooo)
 
 ### Database
 


### PR DESCRIPTION
Adds a link to a terminal command (https://github.com/npahlfer/ooo) that lets you pipe in outputs from other terminal commands "into" Ollama and parse them through your prompt.
This way you can parse command outputs in an easy way!
You can also just prompt Ollama like you normally would eg. `$ ooo how long is a rope`.

Thanks, I love your work!
