### PR TITLE
Add Cache option #1573

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -103,6 +103,7 @@ type Options struct {
 	MirostatEta      float32  `json:"mirostat_eta,omitempty"`
 	PenalizeNewline  bool     `json:"penalize_newline,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
+	Cache            bool     `json:"cache,omitempty"`
 }
 
 // Runner options which must be set when the model is loaded into memory
@@ -355,6 +356,7 @@ func DefaultOptions() Options {
 		MirostatEta:      0.1,
 		PenalizeNewline:  true,
 		Seed:             -1,
+		Cache:            true,
 
 		Runner: Runner{
 			// options set when the model is loaded

--- a/docs/api.md
+++ b/docs/api.md
@@ -306,7 +306,8 @@ curl http://localhost:11434/api/generate -d '{
     "embedding_only": false,
     "rope_frequency_base": 1.1,
     "rope_frequency_scale": 0.8,
-    "num_thread": 8
+    "num_thread": 8,
+    "cache": true
   }
 }'
 ```

--- a/llm/ext_server.go
+++ b/llm/ext_server.go
@@ -234,7 +234,8 @@ func predict(llm extServer, opts api.Options, ctx context.Context, predict Predi
 		"penalize_nl":       opts.PenalizeNewline,
 		"seed":              opts.Seed,
 		"stop":              opts.Stop,
-		"image_data":        imageData,
+		"image_data":        imageData,		
+		"cache_prompt":      opts.Cache,
 	}
 
 	if predict.Format == "json" {


### PR DESCRIPTION
This PR, adds the API option "cache", that allows the llama.cpp server to cache our prompt Eval and the response.
This speed-up follow-up calls immensely for some models, if you use it over the API, with the same prompt (or even partial ones), it will speed up subsequent calls, since it skips the evaluation of the prompt.

Also, this PR includes commands /set cache and /set nocache to give users the ability to enable prompt caching in the official CLI.


* Add a new entry "cache" to the options object that is passed to the worker
* Add commands /set cache and /set nocache to allow this in the repl cli
* Update docs


This is a partial fix for, Enable prompt cache #1573, we might need to patch llama.cpp at some point to allow us full flexibility.