### PR TITLE
Refactor builder dockerfile

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,20 +1,20 @@
 # Ubuntu 20.04 amd64 dependencies
 FROM --platform=linux/amd64 ubuntu:20.04 AS base-amd64
-ARG CUDA_VERSION=11.3.1-1
-ARG CMAKE_VERSION=3.22.1
 # ROCm only supports amd64
 ARG ROCM_VERSION=6.0
 ARG CLBLAST_VER=1.6.1
+ARG CMAKE_VERSION=3.22.1
+
+ENV CUDA_REPO_URL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64"
+ENV ROCM_PATH=/opt/rocm
+ENV DEBIAN_FRONTEND "noninteractive"
+
+ADD https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh /tmp/cmake-installer.sh
+RUN chmod +x /tmp/cmake-installer.sh && /tmp/cmake-installer.sh --skip-license --prefix=/usr
 
 # Note: https://rocm.docs.amd.com/en/latest/release/user_kernel_space_compat_matrix.html
 RUN apt-get update && \
     apt-get install -y wget gnupg && \
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
-    mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
-    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub && \
-    echo "deb [by-hash=no] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" > /etc/apt/sources.list.d/cuda.list && \
-    wget "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh" -O /tmp/cmake-installer.sh && \
-    chmod +x /tmp/cmake-installer.sh && /tmp/cmake-installer.sh --skip-license --prefix=/usr && \
     mkdir --parents --mode=0755 /etc/apt/keyrings && \
     wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor > /etc/apt/keyrings/rocm.gpg && \
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} focal main" > /etc/apt/sources.list.d/rocm.list && \
@@ -22,44 +22,51 @@ RUN apt-get update && \
     echo "Pin: release o=repo.radeon.com" >> /etc/apt/preferences.d/rocm-pin-600 && \
     echo "Pin-Priority: 600" >> /etc/apt/preferences.d/rocm-pin-600 && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install cuda=${CUDA_VERSION} rocm-hip-libraries rocm-device-libs rocm-libs rocm-ocl-icd rocm-hip-sdk rocm-hip-libraries rocm-cmake rocm-clang-ocl rocm-dev
-
-# CLBlast
+    apt-get -y install rocm-hip-libraries rocm-device-libs rocm-libs rocm-ocl-icd rocm-hip-sdk rocm-hip-libraries rocm-cmake rocm-clang-ocl rocm-dev ocl-icd-opencl-dev
 RUN wget -qO- https://github.com/CNugteren/CLBlast/archive/refs/tags/${CLBLAST_VER}.tar.gz | tar zxv -C /tmp/ && \
     cd /tmp/CLBlast-${CLBLAST_VER} && mkdir build && cd build && cmake .. && make && make install
 
-ENV ROCM_PATH=/opt/rocm
 
-# Ubuntu 22.04 arm64 dependencies
+# Ubuntu 20.04 arm64 dependencies
 FROM --platform=linux/arm64 ubuntu:20.04 AS base-arm64
-ARG CUDA_VERSION=11.3.1-1
-ARG CMAKE_VERSION=3.27.6
-RUN apt-get update && \
-    apt-get install -y wget gnupg && \
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/sbsa/cuda-ubuntu2004.pin && \
-    mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
-    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/sbsa//3bf863cc.pub && \
-    echo "deb [by-hash=no] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/sbsa/ /" > /etc/apt/sources.list.d/cuda.list && \
-    wget "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.sh" -O /tmp/cmake-installer.sh && \
-    chmod +x /tmp/cmake-installer.sh && /tmp/cmake-installer.sh --skip-license --prefix=/usr && \
-    apt-get update && \
-    apt-cache madison cuda && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install cuda=${CUDA_VERSION} 
+ENV CUDA_REPO_URL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/sbsa"
+ARG CMAKE_VERSION=3.22.1
+ENV DEBIAN_FRONTEND "noninteractive"
 
-FROM base-${TARGETARCH}
-ARG TARGETARCH
-ARG GOFLAGS="'-ldflags -w -s'"
-ARG CGO_CFLAGS
-ARG GOLANG_VERSION=1.21.3
+ADD https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.sh /tmp/cmake-installer.sh
+RUN chmod +x /tmp/cmake-installer.sh && /tmp/cmake-installer.sh --skip-license --prefix=/usr
+
 
 # Common toolchain
+FROM base-${TARGETARCH} as builder
+ARG TARGETARCH
+ARG GOLANG_VERSION=1.21.3
+ARG CUDA_VERSION=11-3
+
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-10 g++-10 cpp-10 git ocl-icd-opencl-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg gcc-10 g++-10 cpp-10 git && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+
+RUN wget ${CUDA_REPO_URL}/cuda-ubuntu2004.pin -O /etc/apt/preferences.d/cuda-repository-pin-600 && \
+    apt-key adv --fetch-keys ${CUDA_REPO_URL}/3bf863cc.pub && \
+    echo "deb [by-hash=no] ${CUDA_REPO_URL}/ /" > /etc/apt/sources.list.d/cuda.list && \
+    apt-get update && apt-get -y install \
+    cuda-cudart-dev-${CUDA_VERSION} \
+    cuda-command-line-tools-${CUDA_VERSION} \
+    cuda-compiler-${CUDA_VERSION} \
+    cuda-nvml-dev-${CUDA_VERSION} \
+    cuda-libraries-${CUDA_VERSION} \
+    cuda-libraries-dev-${CUDA_VERSION} \
+    cuda-nvrtc-dev-${CUDA_VERSION} \
+    cuda-nvtx-${CUDA_VERSION}
 
 # install go
 ADD https://dl.google.com/go/go${GOLANG_VERSION}.linux-$TARGETARCH.tar.gz /tmp/go${GOLANG_VERSION}.tar.gz
 RUN mkdir -p /usr/local && tar xz -C /usr/local </tmp/go${GOLANG_VERSION}.tar.gz
+
+FROM builder as build
+ARG GOFLAGS="'-ldflags -w -s'"
+ARG CGO_CFLAGS
 
 # build the final binary
 WORKDIR /go/src/github.com/jmorganca/ollama

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -5,10 +5,18 @@ set -eu
 export VERSION=${VERSION:-0.0.0}
 export GOFLAGS="'-ldflags=-w -s \"-X=github.com/jmorganca/ollama/version.Version=$VERSION\" \"-X=github.com/jmorganca/ollama/server.mode=release\"'"
 
+if docker buildx inspect | grep "^Driver:" | grep "docker-container" >/dev/null; then
+    echo "Caching Enabled"
+    CACHE_FLAGS="--cache-from type=local,src=.cache --cache-to type=local,dest=.cache"
+else
+    echo "Caching Disabled"
+    CACHE_FLAGS=""
+fi
+
 mkdir -p dist
 
 for TARGETARCH in amd64 arm64; do
-    docker buildx build --load --platform=linux/$TARGETARCH --build-arg=VERSION --build-arg=GOFLAGS --build-arg=CGO_CFLAGS --cache-from type=local,src=.cache --cache-to type=local,dest=.cache -f Dockerfile.build -t builder:$TARGETARCH .
+    docker buildx build --load --platform=linux/$TARGETARCH --build-arg=VERSION --build-arg=GOFLAGS --build-arg=CGO_CFLAGS ${CACHE_FLAGS} -f Dockerfile.build -t builder:$TARGETARCH .
     docker create --platform linux/$TARGETARCH --name builder-$TARGETARCH builder:$TARGETARCH
     docker cp builder-$TARGETARCH:/go/src/github.com/jmorganca/ollama/ollama ./dist/ollama-linux-$TARGETARCH
     docker rm builder-$TARGETARCH


### PR DESCRIPTION
Reorganize the x86/arm components to be more DRY, and remove the cuda driver

Note: to build locally on arm mac, I need to remove the `--cache-from` and `--cache-to` flags in the script to be able to build without a builder defined.  It seems with a builder, qemu is being used instead of rosetta, and the rocm post-install packaging scripts have some binaries that wont run with qemu resulting in 
```
...
#10 864.1 Error while loading /var/lib/dpkg/info/rocrand.postinst: Exec format error
#10 864.1 dpkg: error processing package rocrand (--configure):
#10 864.1  installed rocrand package post-installation script subprocess returned error exit status 1
```

If I omit creating a buildx builder, the default Docker Desktop build with rosetta works. 