### PR TITLE
Note for non-NVIDIA GPU users and Improve Warning Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ Next, start the server:
 ./ollama serve
 ```
 
+**Note for Non-NVIDIA GPU Users:**
+
+If you encounter a warning about GPU support when running `ollama serve`, disregard the warning and let the command continue running. Ollama will default to using only the CPU.
+
 Finally, in a separate shell, run a model:
 
 ```

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -117,7 +117,7 @@ type ImageData struct {
 }
 
 var (
-	errNvidiaSMI     = errors.New("warning: gpu support may not be enabled, check that you have installed GPU drivers: nvidia-smi command failed")
+	errNvidiaSMI     = errors.New("warning: gpu support may not be enabled, check that you have installed GPU drivers: nvidia-smi command failed, running on CPU only")
 	errAvailableVRAM = errors.New("not enough VRAM available, falling back to CPU only")
 	payloadMissing   = fmt.Errorf("expected dynamic library payloads not included in this build of ollama")
 )

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -117,7 +117,7 @@ type ImageData struct {
 }
 
 var (
-	errNvidiaSMI     = errors.New("warning: gpu support may not be enabled, check that you have installed GPU drivers: nvidia-smi command failed, running on CPU only")
+	errNvidiaSMI     = errors.New("warning: GPU support may not be enabled, check that you have installed GPU drivers: nvidia-smi command failed, running on CPU only")
 	errAvailableVRAM = errors.New("not enough VRAM available, falling back to CPU only")
 	payloadMissing   = fmt.Errorf("expected dynamic library payloads not included in this build of ollama")
 )


### PR DESCRIPTION
Motivation - From the issue, https://github.com/jmorganca/ollama/issues/1594 where a user got confused due to the warning message and has asked questions like "_can i force it to just run on my cpu?_" which calls for clarity in the warning message and better instructions for non-NVIDIA GPU users.

This PR improves the warning message shown to non-NVIDIA GPU users when running `ollama serve`. Additionally, added 
 guidance in the `readme.md`

## Changes
- Modified the `errNvidiaSMI` error message to provide the information that ollama will use CPU.
- Added a line in `readme.md` to inform the users to disregard the message.

resolves #1594 