### PR TITLE
fix: pull either original model or from model on create

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -486,15 +486,12 @@ func CreateModel(ctx context.Context, name, modelFileDir string, commands []pars
 						return err
 					}
 
-					switch {
-					case parent.OriginalModel != "":
-						if err := PullModel(ctx, parent.OriginalModel, &RegistryOptions{}, fn); err != nil {
-							log.Printf("error pulling parent model: %v", err)
-						}
-					default:
-						if err := PullModel(ctx, parent.ShortName, &RegistryOptions{}, fn); err != nil {
-							log.Printf("error pulling model: %v", err)
-						}
+					originalModel := parent.OriginalModel
+					if originalModel == "" {
+						originalModel = parent.ShortName
+					}
+					if err := PullModel(ctx, originalModel, &RegistryOptions{}, fn); err != nil {
+						log.Printf("error pulling parent model: %v", err)
 					}
 
 					// Reset the file pointer to the beginning of the file

--- a/server/images.go
+++ b/server/images.go
@@ -485,9 +485,18 @@ func CreateModel(ctx context.Context, name, modelFileDir string, commands []pars
 					if err != nil {
 						return err
 					}
-					if err := PullModel(ctx, parent.OriginalModel, &RegistryOptions{}, fn); err != nil {
-						log.Printf("error pulling model: %v", err)
+
+					switch {
+					case parent.OriginalModel != "":
+						if err := PullModel(ctx, parent.OriginalModel, &RegistryOptions{}, fn); err != nil {
+							log.Printf("error pulling parent model: %v", err)
+						}
+					default:
+						if err := PullModel(ctx, parent.ShortName, &RegistryOptions{}, fn); err != nil {
+							log.Printf("error pulling model: %v", err)
+						}
 					}
+
 					// Reset the file pointer to the beginning of the file
 					_, err = fromConfigFile.Seek(0, 0)
 					if err != nil {


### PR DESCRIPTION
I created a bug here when accounting for the "pull parent model" case when pull gguf models on deprecated ggml models. In the case of a Modelfile like this:
```
FROM orca-mini
SYSTEM "you are mario"
```
where orca-mini is a `ggml` library model there is no `ParentModel` and the model itself should be pulled.

This handles both:
```
FROM orca-mini
SYSTEM "you are mario"
```
and a child:
```
FROM mario
PARAMETER temperature 0
```
correctly and will pull the root model for both cases.