### PR TITLE
Add ollama user to render group for Radeon support

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,6 +76,10 @@ configure_systemd() {
         status "Creating ollama user..."
         $SUDO useradd -r -s /bin/false -m -d /usr/share/ollama ollama
     fi
+    if getent group render >/dev/null 2>&1; then
+        status "Adding ollama user to render group..."
+        $SUDO usermod -a -G render ollama
+    fi
 
     status "Adding current user to ollama group..."
     $SUDO usermod -a -G ollama $(whoami)


### PR DESCRIPTION
For the ROCm libraries to access the driver, we need to add the ollama user to the render group.

Note: the script will need more work to fully support radeon cards, but this will at least make the installation functional.  Without this change, the server sits in a crash-loop due to lack of permissions to access the driver.