### PR TITLE
Fail fast on WSL1 while allowing on WSL2

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,14 @@ case "$ARCH" in
     *) error "Unsupported architecture: $ARCH" ;;
 esac
 
+KERN=$(uname -r)
+case "$KERN" in
+    *icrosoft*WSL2 | *icrosoft*wsl2) ;;
+    *icrosoft) error "Microsoft WSL1 is not currently supported. Please upgrade to WSL2 with 'wsl --set-version <distro> 2'" ;;
+    *) ;;
+esac
+
+
 SUDO=
 if [ "$(id -u)" -ne 0 ]; then
     # Running as root, no need for sudo


### PR DESCRIPTION
This prevents users from accidentally installing on WSL1 with instructions guiding how to upgrade their WSL instance to version 2.  Once running WSL2 if you have an NVIDIA card, you can follow their instructions to set up GPU passthrough and run models on the GPU.  This is not possible on WSL1.


Example output.

WSL1
```
daniel@DESKTOP-PUNI632:/mnt/c/Users/Daniel$ ./install.sh
ERROR WSL1 is not currently supported - please upgrade to WSL2 with 'wsl --set-version <distro> 2'
daniel@DESKTOP-PUNI632:/mnt/c/Users/Daniel$ uname -r
4.4.0-19041-Microsoft
```

WSL2
```
root@DESKTOP-PUNI632:/mnt/c/Users/Daniel# ./install.sh
>>> Downloading ollama...
################################################################################################################# 100.0% 
...
root@DESKTOP-PUNI632:/mnt/c/Users/Daniel# uname -r
5.15.133.1-microsoft-standard-WSL2
```
