### PR TITLE
Fix CPU only builds

### DIFF
--- a/llm/llama.cpp/gen_linux.sh
+++ b/llm/llama.cpp/gen_linux.sh
@@ -35,6 +35,9 @@ BUILD_DIR="gguf/build/linux/cpu"
 build
 install
 
+# Placeholder to keep go embed happy until we start building dynamic CPU lib variants
+touch ${BUILD_DIR}/lib/dummy.so
+
 if [ -d /usr/local/cuda/lib64/ ]; then
     echo "CUDA libraries detected - building dynamic CUDA library"
     init_vars

--- a/llm/shim_ext_server.go
+++ b/llm/shim_ext_server.go
@@ -147,9 +147,9 @@ func extractDynamicLibs(workDir, glob string) ([]string, error) {
 	if err != nil || len(files) == 0 {
 		return nil, payloadMissing
 	}
-	libs := make([]string, len(files))
+	libs := []string{}
 
-	for i, file := range files {
+	for _, file := range files {
 		pathComps := strings.Split(file, "/")
 		if len(pathComps) != 7 {
 			log.Printf("unexpected payload components: %v", pathComps)
@@ -169,7 +169,7 @@ func extractDynamicLibs(workDir, glob string) ([]string, error) {
 
 		destFile := filepath.Join(targetDir, filepath.Base(file))
 		if strings.Contains(destFile, "server") {
-			libs[i] = destFile
+			libs = append(libs, destFile)
 		}
 
 		_, err = os.Stat(destFile)


### PR DESCRIPTION
Go embed doesn't like when there's no matching files, so put a dummy placeholder in to allow building without any GPU support If no "server" library is found, it's safely ignored at runtime.