### PR TITLE
Offload layers to GPU based on new model size estimates

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -132,7 +132,7 @@ func CheckVRAM() (int64, error) {
 	gpuInfo := GetGPUInfo()
 	if gpuInfo.FreeMemory > 0 && (gpuInfo.Library == "cuda" || gpuInfo.Library == "rocm") {
 		// allocate 384MiB for llama.cpp overhead (outside of model)
-		overhead := 384 * 1024 * 1024
+		overhead := uint64(384 * 1024 * 1024)
 		if gpuInfo.FreeMemory <= overhead {
 			return 0, nil
 		}

--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -131,7 +131,14 @@ func getCPUMem() (memInfo, error) {
 func CheckVRAM() (int64, error) {
 	gpuInfo := GetGPUInfo()
 	if gpuInfo.FreeMemory > 0 && (gpuInfo.Library == "cuda" || gpuInfo.Library == "rocm") {
-		return int64(gpuInfo.FreeMemory), nil
+		// allocate 384MiB for llama.cpp overhead (outside of model)
+		overhead := 384 * 1024 * 1024
+		if gpuInfo.FreeMemory <= overhead {
+			return 0, nil
+		}
+
+		return int64(gpuInfo.FreeMemory - overhead), nil
 	}
+
 	return 0, fmt.Errorf("no GPU detected") // TODO - better handling of CPU based memory determiniation
 }

--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -16,8 +16,6 @@ import (
 	"runtime"
 	"sync"
 	"unsafe"
-
-	"github.com/jmorganca/ollama/api"
 )
 
 type handles struct {
@@ -136,28 +134,4 @@ func CheckVRAM() (int64, error) {
 		return int64(gpuInfo.FreeMemory), nil
 	}
 	return 0, fmt.Errorf("no GPU detected") // TODO - better handling of CPU based memory determiniation
-}
-
-func NumGPU(numLayer, fileSizeBytes int64, opts api.Options) int {
-	if opts.NumGPU != -1 {
-		return opts.NumGPU
-	}
-	info := GetGPUInfo()
-	if info.Library == "cpu" || info.Library == "default" {
-		return 0
-	}
-
-	/*
-		Calculate bytes per layer, this will roughly be the size of the model file divided by the number of layers.
-		We can store the model weights and the kv cache in vram,
-		to enable kv chache vram storage add two additional layers to the number of layers retrieved from the model file.
-	*/
-	bytesPerLayer := uint64(fileSizeBytes / numLayer)
-
-	// 75% of the absolute max number of layers we can fit in available VRAM, off-loading too many layers to the GPU can cause OOM errors
-	layers := int(info.FreeMemory/bytesPerLayer) * 3 / 4
-
-	log.Printf("%d MB VRAM available, loading up to %d %s GPU layers out of %d", info.FreeMemory/(1024*1024), layers, info.Library, numLayer)
-
-	return layers
 }

--- a/gpu/gpu_darwin.go
+++ b/gpu/gpu_darwin.go
@@ -6,18 +6,30 @@ import "C"
 import (
 	"runtime"
 
-	"github.com/jmorganca/ollama/api"
+	"github.com/pbnjay/memory"
 )
 
 // CheckVRAM returns the free VRAM in bytes on Linux machines with NVIDIA GPUs
 func CheckVRAM() (int64, error) {
-	// TODO - assume metal, and return free memory?
-	return 0, nil
+	if runtime.GOARCH == "amd64" {
+		return 0, nil
+	}
 
+	// on macOS, there's already buffer for available vram (see below) so just return the total
+	systemMemory := int64(memory.TotalMemory())
+
+	// macOS limits how much memory is available to the GPU based on the amount of system memory
+	// TODO: handle case where iogpu.wired_limit_mb is set to a higher value
+	if systemMemory <= 36*1024*1024*1024 {
+		systemMemory = systemMemory * 2 / 3
+	} else {
+		systemMemory = systemMemory * 3 / 4
+	}
+
+	return systemMemory, nil
 }
 
 func GetGPUInfo() GpuInfo {
-	// TODO - Metal vs. x86 macs...
 	mem, _ := getCPUMem()
 	return GpuInfo{
 		Library: "default",
@@ -30,19 +42,6 @@ func getCPUMem() (memInfo, error) {
 		TotalMemory: 0,
 		FreeMemory:  0,
 	}, nil
-}
-
-func NumGPU(numLayer, fileSizeBytes int64, opts api.Options) int {
-	if opts.NumGPU != -1 {
-		return opts.NumGPU
-	}
-
-	// metal only supported on arm64
-	if runtime.GOARCH == "arm64" {
-		return 1
-	}
-
-	return 0
 }
 
 func nativeInit() error {

--- a/gpu/gpu_darwin.go
+++ b/gpu/gpu_darwin.go
@@ -12,6 +12,7 @@ import (
 // CheckVRAM returns the free VRAM in bytes on Linux machines with NVIDIA GPUs
 func CheckVRAM() (int64, error) {
 	if runtime.GOARCH == "amd64" {
+		// gpu not supported, this may not be metal
 		return 0, nil
 	}
 

--- a/llm/ext_server_default.go
+++ b/llm/ext_server_default.go
@@ -54,9 +54,9 @@ func (llm *llamaExtServer) llama_server_release_json_resp(json_resp **C.char) {
 	C.llama_server_release_json_resp(json_resp)
 }
 
-func newDefaultExtServer(model string, adapters, projectors []string, numLayers int64, opts api.Options) (extServer, error) {
+func newDefaultExtServer(model string, adapters, projectors []string, opts api.Options) (extServer, error) {
 	server := &llamaExtServer{opts}
-	return newExtServer(server, model, adapters, projectors, numLayers, opts)
+	return newExtServer(server, model, adapters, projectors, opts)
 }
 
 func (llm *llamaExtServer) Predict(ctx context.Context, pred PredictOpts, fn func(PredictResult)) error {

--- a/llm/ggml.go
+++ b/llm/ggml.go
@@ -78,7 +78,11 @@ type model interface {
 	ModelFamily() string
 	ModelType() string
 	FileType() string
-	NumLayers() int64
+	NumLayers() uint32
+	NumGQA() uint32
+	NumEmbed() uint32
+	NumHead() uint32
+	NumHeadKv() uint32
 }
 
 type container interface {

--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -272,14 +272,49 @@ func (llm *ggufModel) Decode(rso *readSeekOffset) error {
 	return nil
 }
 
-func (llm *ggufModel) NumLayers() int64 {
+func (llm *ggufModel) NumLayers() uint32 {
 	value, exists := llm.kv[fmt.Sprintf("%s.block_count", llm.ModelFamily())]
 	if !exists {
 		return 0
 	}
 
-	v := value.(uint32)
-	return int64(v)
+	return value.(uint32)
+}
+
+func (llm *ggufModel) NumHead() uint32 {
+	value, exists := llm.kv[fmt.Sprintf("%s.attention.head_count", llm.ModelFamily())]
+	if !exists {
+		return 0
+	}
+
+	return value.(uint32)
+}
+
+func (llm *ggufModel) NumEmbed() uint32 {
+	value, exists := llm.kv[fmt.Sprintf("%s.embedding_length", llm.ModelFamily())]
+	if !exists {
+		return 0
+	}
+
+	return value.(uint32)
+}
+
+func (llm *ggufModel) NumHeadKv() uint32 {
+	value, exists := llm.kv[fmt.Sprintf("%s.attention.head_count_kv", llm.ModelFamily())]
+	if !exists {
+		return 0
+	}
+
+	return value.(uint32)
+}
+
+func (llm *ggufModel) NumGQA() uint32 {
+	numHeadKv := llm.NumHeadKv()
+	if numHeadKv == 0 {
+		return 0
+	}
+
+	return llm.NumHead() / numHeadKv
 }
 
 func (llm ggufModel) readU8(r io.Reader) uint8 {

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"sync"
 	"time"
 
 	"github.com/jmorganca/ollama/api"
@@ -43,69 +42,11 @@ number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
 ws ::= ([ \t\n] ws)?
 `
 
-type llamaModel struct {
-	hyperparameters llamaHyperparameters
-}
-
-func (llm *llamaModel) ModelFamily() string {
-	return "llama"
-}
-
-func llamaModelType(numLayer uint32) string {
-	switch numLayer {
-	case 26:
-		return "3B"
-	case 32:
-		return "7B"
-	case 40:
-		return "13B"
-	case 48:
-		return "34B"
-	case 60:
-		return "30B"
-	case 80:
-		return "65B"
-	default:
-		return "unknown"
-	}
-}
-
-func (llm *llamaModel) ModelType() string {
-	return llamaModelType(llm.hyperparameters.NumLayer)
-}
-
-func (llm *llamaModel) FileType() string {
-	return fileType(llm.hyperparameters.FileType)
-}
-
-func (llm *llamaModel) NumLayers() int64 {
-	return int64(llm.hyperparameters.NumLayer)
-}
-
-type llamaHyperparameters struct {
-	// NumVocab is the size of the model's vocabulary.
-	NumVocab uint32
-
-	// NumEmbd is the size of the model's embedding layer.
-	NumEmbd uint32
-	NumMult uint32
-	NumHead uint32
-
-	// NumLayer is the number of layers in the model.
-	NumLayer uint32
-	NumRot   uint32
-
-	// FileType describes the quantization level of the model, e.g. Q4_0, Q5_K, etc.
-	FileType uint32
-}
-
 type Running struct {
 	Port          int
 	Cmd           *exec.Cmd
 	Cancel        context.CancelFunc
-	exitOnce      sync.Once
-	exitCh        chan error // channel to receive the exit status of the subprocess
-	*StatusWriter            // captures error messages from the llama runner process
+	*StatusWriter // captures error messages from the llama runner process
 }
 
 type ImageData struct {

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -57,7 +57,7 @@ func New(workDir, model string, adapters, projectors []string, opts api.Options)
 	// TODO: use actual model size
 	requiredModel := ggml.Size
 
-	// fp16 k,v matrices each require = n_ctx * n_layer * n_embd / n_head * n_head_kv * 2 bytes each
+	// fp16 k,v matrices each require = n_ctx * n_layer * n_embd / n_head * n_head_kv * 2 bytes each * 2 key and value
 	requiredKv := 2 * 2 * int64(opts.NumCtx) * int64(ggml.NumLayers()) * int64(ggml.NumEmbed()) * int64(ggml.NumHeadKv()) / int64(ggml.NumHead())
 
 	// this amount is the overhead + tensors in memory

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -7,10 +7,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/pbnjay/memory"
-
 	"github.com/jmorganca/ollama/api"
-	"github.com/jmorganca/ollama/format"
 	"github.com/jmorganca/ollama/gpu"
 )
 
@@ -40,32 +37,74 @@ func New(workDir, model string, adapters, projectors []string, opts api.Options)
 		return nil, err
 	}
 
-	if runtime.GOOS == "darwin" {
-		var requiredMemory int64
-		var f16Multiplier int64 = 2
+	if opts.NumCtx < 4 {
+		opts.NumCtx = 4
+	}
 
-		switch ggml.ModelType() {
-		case "3B", "7B":
-			requiredMemory = 8 * format.GigaByte
-		case "13B":
-			requiredMemory = 16 * format.GigaByte
-		case "30B", "34B", "40B":
-			requiredMemory = 32 * format.GigaByte
-		case "47B":
-			requiredMemory = 48 * format.GigaByte
-		case "65B", "70B":
-			requiredMemory = 64 * format.GigaByte
-		case "180B":
-			requiredMemory = 128 * format.GigaByte
-			f16Multiplier = 4
-		}
+	fmt.Println("size", ggml.Size)
+	fmt.Println("filetype", ggml.FileType())
+	fmt.Println("architecture", ggml.ModelFamily())
+	fmt.Println("type", ggml.ModelType())
+	fmt.Println("name", ggml.Name())
+	fmt.Println("embd", ggml.NumEmbed())
+	fmt.Println("head", ggml.NumHead())
+	fmt.Println("head_kv", ggml.NumHeadKv())
+	fmt.Println("gqa", ggml.NumGQA())
 
-		systemMemory := int64(memory.TotalMemory())
+	available, _ := gpu.CheckVRAM()
 
-		if ggml.FileType() == "F16" && requiredMemory*f16Multiplier > systemMemory {
-			return nil, fmt.Errorf("F16 model requires at least %s of memory", format.HumanBytes(requiredMemory))
-		} else if requiredMemory > systemMemory {
-			return nil, fmt.Errorf("model requires at least %s of memory", format.HumanBytes(requiredMemory))
+	// For now assume filesize = model size
+	// TODO: use actual model size
+	requiredModel := ggml.Size
+
+	// fp16 k,v matrices each require = n_ctx * n_layer * n_embd / n_head * n_head_kv * 2 bytes each
+	requiredKv := 2 * 2 * int64(opts.NumCtx) * int64(ggml.NumLayers()) * int64(ggml.NumEmbed()) * int64(ggml.NumHeadKv()) / int64(ggml.NumHead())
+
+	// this amount is the overhead + tensors in memory
+	// TODO: get this from the llama.cpp's graph calcluations instead of
+	// guessing it's ~1/8th of the kv cache times gqa
+	// this is slightly (~25%) higher than what it is in reality
+	requiredAlloc := int64(ggml.NumGQA()) * requiredKv / 8
+
+	fmt.Println("system memory ", available)
+	fmt.Println("required model", requiredModel)
+	fmt.Println("required kv", requiredKv)
+	fmt.Println("required alloc", requiredAlloc)
+	fmt.Println("required total", requiredModel+requiredKv+requiredAlloc)
+
+	if opts.NumGPU == -1 {
+		opts.NumGPU = int(ggml.NumLayers())
+	}
+
+	// decide how many layers to put on the GPU
+	if opts.NumGPU > 0 {
+		switch runtime.GOOS {
+		case "darwin":
+			if requiredModel+requiredKv+requiredAlloc > available {
+				fmt.Println("not enough vram available, falling back to CPU only")
+				opts.NumGPU = 0
+			}
+		default:
+			info := gpu.GetGPUInfo()
+			if info.Library == "cpu" || info.Library == "default" {
+				opts.NumGPU = 0
+				break
+			}
+
+			// model and kv cache get loaded into vram
+			vram := requiredModel + requiredKv
+
+			var layers int64
+			if vram > available {
+				// TODO: calculate actual bytes per layer vs this estimation
+				bytesPerLayer := int64(vram / int64(ggml.NumLayers()))
+				layers = vram / bytesPerLayer
+			}
+
+			if layers < int64(opts.NumGPU) {
+				fmt.Println("only loading", layers, "layers")
+				opts.NumGPU = int(layers)
+			}
 		}
 	}
 
@@ -73,7 +112,7 @@ func New(workDir, model string, adapters, projectors []string, opts api.Options)
 	opts.RopeFrequencyBase = 0.0
 	opts.RopeFrequencyScale = 0.0
 	gpuInfo := gpu.GetGPUInfo()
-	return newLlmServer(gpuInfo.Library, model, adapters, projectors, ggml.NumLayers(), opts)
+	return newLlmServer(gpuInfo.Library, model, adapters, projectors, opts)
 }
 
 // Give any native cgo implementations an opportunity to initialize
@@ -81,9 +120,9 @@ func Init(workdir string) error {
 	return nativeInit(workdir)
 }
 
-func newLlmServer(library, model string, adapters, projectors []string, numLayers int64, opts api.Options) (extServer, error) {
+func newLlmServer(library, model string, adapters, projectors []string, opts api.Options) (extServer, error) {
 	if _, libPresent := AvailableShims[library]; libPresent && library != "default" {
-		srv, err := newDynamicShimExtServer(AvailableShims[library], model, adapters, projectors, numLayers, opts)
+		srv, err := newDynamicShimExtServer(AvailableShims[library], model, adapters, projectors, opts)
 		if err == nil {
 			return srv, nil
 		}
@@ -91,6 +130,5 @@ func newLlmServer(library, model string, adapters, projectors []string, numLayer
 		// TODO - update some state to indicate we were unable to load the GPU library for future "info" ux
 	}
 
-	return newDefaultExtServer(model, adapters, projectors, numLayers, opts)
-
+	return newDefaultExtServer(model, adapters, projectors, opts)
 }

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -116,9 +116,6 @@ func New(workDir, model string, adapters, projectors []string, opts api.Options)
 			log.Println("splitting", available, "of available memory bytes into layers")
 			bytesPerLayer := int64((requiredModel + requiredKv) / int64(ggml.NumLayers()))
 			log.Println("bytes per layer:", bytesPerLayer)
-
-			// leave some room for overhead
-			// available = (available * 9) / 10
 			layers := available / bytesPerLayer
 			if layers < int64(opts.NumGPU) {
 				opts.NumGPU = int(layers)

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -62,10 +62,8 @@ func New(workDir, model string, adapters, projectors []string, opts api.Options)
 
 	// this amount is the overhead + tensors in memory
 	// TODO: get this from the llama.cpp's graph calcluations instead of
-	// guessing it's ~1/8th of the kv cache times gqa
-	// this is slightly (~25%) higher than what it is in reality
-	// TODO: this needs to account for batch size != 512
-	requiredAlloc := int64(ggml.NumGQA()) * requiredKv / 8
+	// guessing it's ~1/7th of the kv cache times gqa
+	requiredAlloc := int64(ggml.NumGQA()) * requiredKv / 7
 
 	requiredTotal := requiredModel + requiredKv + requiredAlloc
 

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -77,6 +77,7 @@ func New(workDir, model string, adapters, projectors []string, opts api.Options)
 	library := info.Library
 
 	if opts.NumGPU == -1 {
+		// default to offloading all layers
 		opts.NumGPU = int(ggml.NumLayers()) + 1
 	}
 

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -57,7 +57,7 @@ func New(workDir, model string, adapters, projectors []string, opts api.Options)
 	// TODO: use actual model size
 	requiredModel := ggml.Size
 
-	// fp16 k,v matrices each require = n_ctx * n_layer * n_embd / n_head * n_head_kv * 2 bytes each * 2 key and value
+	// fp16 k,v matrices require = n_ctx * n_layer * n_embd / n_head * n_head_kv * 2 bytes each * 2 key and value
 	requiredKv := 2 * 2 * int64(opts.NumCtx) * int64(ggml.NumLayers()) * int64(ggml.NumEmbed()) * int64(ggml.NumHeadKv()) / int64(ggml.NumHead())
 
 	// this amount is the overhead + tensors in memory

--- a/llm/shim_darwin.go
+++ b/llm/shim_darwin.go
@@ -16,7 +16,7 @@ import (
 //go:embed llama.cpp/ggml-metal.metal
 var libEmbed embed.FS
 
-func newDynamicShimExtServer(library, model string, adapters, projectors []string, numLayers int64, opts api.Options) (extServer, error) {
+func newDynamicShimExtServer(library, model string, adapters, projectors []string, opts api.Options) (extServer, error) {
 	// should never happen...
 	return nil, fmt.Errorf("Dynamic library loading not supported on Mac")
 }

--- a/llm/shim_ext_server.go
+++ b/llm/shim_ext_server.go
@@ -72,7 +72,7 @@ func (llm *shimExtServer) llama_server_release_json_resp(json_resp **C.char) {
 	C.dynamic_shim_llama_server_release_json_resp(llm.s, json_resp)
 }
 
-func newDynamicShimExtServer(library, model string, adapters, projectors []string, numLayers int64, opts api.Options) (extServer, error) {
+func newDynamicShimExtServer(library, model string, adapters, projectors []string, opts api.Options) (extServer, error) {
 	shimMutex.Lock()
 	defer shimMutex.Unlock()
 	updatePath(filepath.Dir(library))
@@ -90,7 +90,7 @@ func newDynamicShimExtServer(library, model string, adapters, projectors []strin
 		options: opts,
 	}
 	log.Printf("Loading Dynamic Shim llm server: %s", library)
-	return newExtServer(llm, model, adapters, projectors, numLayers, opts)
+	return newExtServer(llm, model, adapters, projectors, opts)
 }
 
 func (llm *shimExtServer) Predict(ctx context.Context, pred PredictOpts, fn func(PredictResult)) error {


### PR DESCRIPTION
This PR fixes a large number of crashes and "out of memory" errors related to VRAM allocation, by using a more accurate estimation of how much memory is required to run a model with a given context size.

Models such as `mixtral` will now run on lower end hardware that would previously before, even if defaulting to the CPU is required. Also, more layers are loaded to Nvidia GPUs which should result in a speedup on Linux.

Details:
- VRAM estimation now accounts for the kv cache and tensor graph (which can grow to GiBs for large context sizes)
- On macOS, Ollama will now run in CPU mode, even on Apple Silicon (`arm64`) if the GPU doesn't have enough VRAM. Models such as `mixtral`, `llama2:70b`, etc will now work (perhaps slowly) instead of crashing
- On Linux, the number of layers to be offloaded to the GPU now accounts for the kv cache which is also partially offloaded

Todo in a follow up:
- Handle smaller batch sizes as mention in #1812
- Still seeing some errors with very large context sizes (64k, 128k)
- Limit `num_ctx` to what the model is trained on

Fixes #1838
Fixes #1812
Fixes #1516 
Fixes #1674
Fixes #1374
Fixes #1534
Fixes #1303
Fixes #1413
Fixes #1636
Fixes #1837
Fixes #1627
Fixes #1566
Fixes #1576
Fixes #1703 


