### PR TITLE
remove ggml automatic re-pull

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -149,7 +149,7 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 
 	name := args[0]
 	// check if the model exists on the server
-	model, err := client.Show(cmd.Context(), &api.ShowRequest{Name: name})
+	_, err = client.Show(cmd.Context(), &api.ShowRequest{Name: name})
 	var statusError api.StatusError
 	switch {
 	case errors.As(err, &statusError) && statusError.StatusCode == http.StatusNotFound:
@@ -158,20 +158,6 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 		}
 	case err != nil:
 		return err
-	default:
-		// the model was found, check if it is in the correct format
-		if model.Details.Format != "" && model.Details.Format != "gguf" {
-			// pull and retry to see if the model has been updated
-			parts := strings.Split(name, string(os.PathSeparator))
-			if len(parts) == 1 {
-				// this is a library model, log some info
-				fmt.Fprintln(os.Stderr, "This model is no longer compatible with Ollama. Pulling a new version...")
-			}
-			if err := PullHandler(cmd, []string{name}); err != nil {
-				fmt.Printf("Error: %s\n", err)
-				return fmt.Errorf("unsupported model, please update this model to gguf format") // relay the original error
-			}
-		}
 	}
 
 	return RunGenerate(cmd, args)

--- a/server/images.go
+++ b/server/images.go
@@ -478,32 +478,6 @@ func CreateModel(ctx context.Context, name, modelFileDir string, commands []pars
 					return err
 				}
 
-				// if the model is not in gguf format, pull the base model to try and get it in gguf format
-				if fromConfig.ModelFormat != "gguf" {
-					fn(api.ProgressResponse{Status: "updating base model"})
-					parent, err := GetModel(c.Args)
-					if err != nil {
-						return err
-					}
-
-					originalModel := parent.OriginalModel
-					if originalModel == "" {
-						originalModel = parent.ShortName
-					}
-					if err := PullModel(ctx, originalModel, &RegistryOptions{}, fn); err != nil {
-						log.Printf("error pulling parent model: %v", err)
-					}
-
-					// Reset the file pointer to the beginning of the file
-					_, err = fromConfigFile.Seek(0, 0)
-					if err != nil {
-						return fmt.Errorf("update from config after pull: %w", err)
-					}
-					if err := json.NewDecoder(fromConfigFile).Decode(&fromConfig); err != nil {
-						return err
-					}
-				}
-
 				// if the model is still not in gguf format, error out
 				if fromConfig.ModelFormat != "gguf" {
 					return fmt.Errorf("%s is not in gguf format, this base model is not compatible with this version of ollama", c.Args)


### PR DESCRIPTION
Remove ggml automatic re-pull now that ggml removal has been rolled out. This prevents a possible future bug where non-ggml models always get pulled on run.

When an unsupported model format is run the error message is displayed to the user:
```
$ ollama run orca-mini
Error: unsupported model format: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull orca-mini:latest`

$ ollama create mario -f ~/models/mario/Modelfile
transferring model data
reading model metadata
Error: orca-mini is not in gguf format, this base model is not compatible with this version of ollama
```