### PR TITLE
Set corret CUDA minimum compute capability version

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -26,8 +26,8 @@ type handles struct {
 var gpuMutex sync.Mutex
 var gpuHandles *handles = nil
 
-// TODO verify this is the correct min version
-const CudaComputeMajorMin = 5
+// With our current CUDA compile flags, 5.2 and older will not work properly
+const CudaComputeMajorMin = 6
 
 // Note: gpuMutex must already be held
 func initGPUHandles() {


### PR DESCRIPTION
If you attempt to run the current CUDA build on compute capability 5.2 cards, you'll hit the following failure:
cuBLAS error 15 at ggml-cuda.cu:7956: the requested functionality is not supported