### PR TITLE
Typo Correction in API Documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -409,7 +409,7 @@ A stream of JSON objects is returned:
   "model": "llama2",
   "created_at": "2023-08-04T08:52:19.385406455-07:00",
   "message": {
-    "role": "assisant",
+    "role": "assistant",
     "content": "The",
     "images": null
   },
@@ -505,7 +505,7 @@ A stream of JSON objects is returned:
   "model": "llama2",
   "created_at": "2023-08-04T08:52:19.385406455-07:00",
   "message": {
-    "role": "assisant",
+    "role": "assistant",
     "content": "The"
   },
   "done": false


### PR DESCRIPTION
I've noticed a small typo in the API documentation and have submitted a fix for it. The "role" value was written as "assisant" which I've updated to "assistant". 