### PR TITLE
feat: load ~/.ollama/.env using godotenv

### DIFF
--- a/cmd/dotenv.go
+++ b/cmd/dotenv.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/joho/godotenv"
+	"os"
+	"path/filepath"
+)
+
+// LoadDotEnvFromOllamaFolder loads environment variables from a .env file located in the ~/.ollama directory.
+// If the file does not exist, the function returns nil without an error.
+func LoadDotEnvFromOllamaFolder() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	envPath := filepath.Join(home, ".ollama", ".env")
+
+	// Check if the .env file exists
+	if _, err := os.Stat(envPath); os.IsNotExist(err) {
+		// If the file does not exist, return nil without an error
+		return nil
+	} else if err != nil {
+		// If there is another error when checking the file, return that error
+		return fmt.Errorf("failed to check if .env file exists: %w", err)
+	}
+
+	// Load the .env file
+	if err := godotenv.Load(envPath); err != nil {
+		return fmt.Errorf("could not load %s: %w", envPath, err)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/main.go
+++ b/main.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"context"
+	"log"
 
 	"github.com/jmorganca/ollama/cmd"
 	"github.com/spf13/cobra"
 )
 
 func main() {
+	err := cmd.LoadDotEnvFromOllamaFolder()
+	if err != nil {
+		log.Fatal(err)
+	}
 	cobra.CheckErr(cmd.NewCLI().ExecuteContext(context.Background()))
 }


### PR DESCRIPTION
- More generic than https://github.com/jmorganca/ollama/pull/1846
- Slots in simply with the existing environment variable configuration
  - Can be used to set environment variables on MacOS for e.g. OLLAMA_ORIGINS without needing to fiddle around with plist/SIP
