### PR TITLE
Bump llama.cpp to b1842 and add new cuda lib dep

### DIFF
--- a/llm/generate/gen_linux.sh
+++ b/llm/generate/gen_linux.sh
@@ -141,6 +141,7 @@ if [ -d "${CUDA_LIB_DIR}" ]; then
         ${CUDA_LIB_DIR}/libcublasLt_static.a \
         ${CUDA_LIB_DIR}/libcudadevrt.a \
         ${CUDA_LIB_DIR}/libculibos.a \
+        -lcuda \
         -lrt -lpthread -ldl -lstdc++ -lm
 fi
 


### PR DESCRIPTION
Upstream llama.cpp has added a new dependency with the NVIDIA CUDA Driver Libraries (libcuda.so) which is part of the driver distribution, not the general cuda libraries, and is not available as an archive, so we can not statically link it.  This may introduce some additional compatibility challenges which we'll need to keep an eye on.

Marking draft until we can test on more driver/cuda version combinations to ensure this doesn't cause compatibility problems.