### PR TITLE
fix gpu_test.go Error (same type) uint64->uint32

### DIFF
--- a/gpu/gpu_test.go
+++ b/gpu/gpu_test.go
@@ -18,7 +18,7 @@ func TestBasicGetGPUInfo(t *testing.T) {
 	case "linux", "windows":
 		assert.Greater(t, info.TotalMemory, uint64(0))
 		assert.Greater(t, info.FreeMemory, uint64(0))
-		assert.Greater(t, info.DeviceCount, uint64(0))
+		assert.Greater(t, info.DeviceCount, uint32(0))
 	default:
 		return
 	}


### PR DESCRIPTION
When running the test suite on linux with a cuda build I get the following error without this commit:

```log
--- FAIL: TestBasicGetGPUInfo (0.06s)
    gpu_test.go:21: 
                Error Trace:    /build/ollama-cuda/src/ollama/gpu/gpu_test.go:21
                Error:          Elements should be the same type
                Test:           TestBasicGetGPUInfo
FAIL
FAIL    github.com/jmorganca/ollama/gpu 0.078s
```

This was due to a type mismatch between `GetGPUInfo()` and the corresponding `TestBasicGetGPUInfo()` test. This simple commit fixes it on the test side and now I get the following test output:

```log
ok      github.com/jmorganca/ollama/gpu 0.090s
```

(my first line of go btw.)