### PR TITLE
Add semantic kernel to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama for Dart](https://github.com/breitburg/dart-ollama)
 - [Ollama for Laravel](https://github.com/cloudstudio/ollama-laravel)
 - [LangChainDart](https://github.com/davidmigloz/langchain_dart)
+- [Semantic Kernel - Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/ai/ollama)
 
 ### Mobile
 


### PR DESCRIPTION
We just released support for Ollama in the Python version of Semantic Kernel, this links directly there. Would love to move this to a package approach instead of using a http request, but that can be done once your work on that is completed as mentioned here #1857.