### PR TITLE
fix build and lint

### DIFF
--- a/llm/llm.go
+++ b/llm/llm.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"runtime"

--- a/llm/payload_common.go
+++ b/llm/payload_common.go
@@ -76,7 +76,7 @@ func getDynLibs(gpuInfo gpu.GpuInfo) []string {
 		}
 	}
 
-	// Finaly, if we didn't find any matches, LCD CPU FTW
+	// Finally, if we didn't find any matches, LCD CPU FTW
 	if len(dynLibs) == 0 {
 		dynLibs = []string{availableDynLibs["cpu"]}
 	}

--- a/llm/payload_common.go
+++ b/llm/payload_common.go
@@ -3,13 +3,13 @@ package llm
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"io"
 	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 
 	"github.com/jmorganca/ollama/gpu"


### PR DESCRIPTION
x/exp/slices is compatible with 1.20 while slices is not

also fix llm/llm.go where fmt is used but not imported