### PR TITLE
use g++ to build `libext_server.so` on linux

### DIFF
--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -52,7 +52,7 @@ install() {
 }
 
 link_server_lib() {
-    gcc -fPIC -g -shared -o ${BUILD_DIR}/lib/libext_server.so \
+    g++ -fPIC -g -shared -o ${BUILD_DIR}/lib/libext_server.so \
         -Wl,--whole-archive \
         ${BUILD_DIR}/lib/libext_server.a \
         -Wl,--no-whole-archive \


### PR DESCRIPTION
Fixes the build error:

```
Error: Unable to load dynamic library: Unable to load dynamic server library: /tmp/ollama3730278603/cpu/libext_server.so: undefined symbol: _ZTVN10cxxabiv117class
```

cc @dhiltgen 