### PR TITLE
Fix intel mac build

### DIFF
--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -75,7 +75,7 @@ func newDynExtServer(library, model string, adapters, projectors []string, opts 
 	updatePath(filepath.Dir(library))
 	libPath := C.CString(library)
 	defer C.free(unsafe.Pointer(libPath))
-	resp := newExtServerResp(128)
+	resp := newExtServerResp(512)
 	defer freeExtServerResp(resp)
 	var srv C.struct_dynamic_llama_server
 	C.dyn_init(libPath, &srv, &resp)

--- a/llm/generate/gen_darwin.sh
+++ b/llm/generate/gen_darwin.sh
@@ -14,9 +14,11 @@ BUILD_DIR="${LLAMACPP_DIR}/build/darwin/metal"
 case "${GOARCH}" in
 "amd64")
     CMAKE_DEFS="-DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_OSX_ARCHITECTURES=x86_64 -DLLAMA_METAL=off -DLLAMA_NATIVE=off -DLLAMA_AVX=on -DLLAMA_AVX2=off -DLLAMA_AVX512=off -DLLAMA_FMA=off -DLLAMA_F16C=off ${CMAKE_DEFS}"
+    ARCH="x86_64"
     ;;
 "arm64")
     CMAKE_DEFS="-DCMAKE_SYSTEM_PROCESSOR=arm64 -DCMAKE_OSX_ARCHITECTURES=arm64 -DLLAMA_METAL=on ${CMAKE_DEFS}"
+    ARHC="arm64"
     ;;
 *)
     echo "GOARCH must be set"
@@ -30,6 +32,7 @@ apply_patches
 build
 install
 gcc -fPIC -g -shared -o ${BUILD_DIR}/lib/libext_server.so \
+    -arch ${ARCH} \
     -Wl,-force_load ${BUILD_DIR}/lib/libext_server.a \
     ${BUILD_DIR}/lib/libcommon.a \
     ${BUILD_DIR}/lib/libllama.a \


### PR DESCRIPTION
Make sure we're building an x86 ext_server lib when cross-compiling

Prior to this fix, running the cross-compiled binary on an intel mac produced the following error:
```
2024/01/13 14:38:47 llm.go:66: not enough vram available, falling back to CPU only
2024/01/13 14:38:47 cpu_common.go:15: CPU has AVX
2024/01/13 14:38:47 dyn_ext_server.go:384: Updating LD_LIBRARY_PATH to /var/folders/z8/jy4xc40953n1tfs96m6gnzkr0000gn/T/ollama2093980092/metal:
loading /var/folders/z8/jy4xc40953n1tfs96m6gnzkr0000gn/T/ollama2093980092/metal/libext_server.so library
2024/01/13 14:38:47 llm.go:151: Failed to load dynamic library /var/folders/z8/jy4xc40953n1tfs96m6gnzkr0000gn/T/ollama2093980092/metal/libext_server.so  Unable to load dynamic library: Unable to load dynamic server library: dlopen(/var/folders/z8/jy4xc40953n1tfs96m6gnzkr0000gn/T/ollama2093980092/metal/libext_server.so, 2): no suitable image found.  Did find:
	/var/folders/z8/jy4xc40953n1tfs96m6gnzkr0000gn/T/ollama2093980092/metal/libext_server.so: mach-o, but wrong architecture
	/var/folders/z8/jy4xc40953n1tfs96m6gnzkr0000gn/T/ollama2093980092/metal/libext_server.so: stat() failed with errno=4
[GIN] 2024/01/13 - 14:38:47 | 500 |  416.860287ms |       127.0.0.1 | POST     "/api/chat"
```