### PR TITLE
Fix CPU-only build under Android Termux enviornment.

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -63,6 +63,7 @@ func initGPUHandles() {
 
 	// TODO - if the ollama build is CPU only, don't do these checks as they're irrelevant and confusing
 
+	gpuHandles = &handles{nil, nil}
 	var cudaMgmtName string
 	var cudaMgmtPatterns []string
 	var rocmMgmtName string
@@ -87,7 +88,6 @@ func initGPUHandles() {
 	}
 
 	slog.Info("Detecting GPU type")
-	gpuHandles = &handles{nil, nil}
 	cudaLibPaths := FindGPULibs(cudaMgmtName, cudaMgmtPatterns)
 	if len(cudaLibPaths) > 0 {
 		cuda := LoadCUDAMgmt(cudaLibPaths)

--- a/llm/dyn_ext_server.c
+++ b/llm/dyn_ext_server.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(__TERMUX__)
 #include <dlfcn.h>
 #define LOAD_LIBRARY(lib, flags) dlopen(lib, flags)
 #define LOAD_SYMBOL(handle, sym) dlsym(handle, sym)

--- a/llm/dyn_ext_server.c
+++ b/llm/dyn_ext_server.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(__linux__) && !defined(__TERMUX__)
+#ifdef __linux__
 #include <dlfcn.h>
 #define LOAD_LIBRARY(lib, flags) dlopen(lib, flags)
 #define LOAD_SYMBOL(handle, sym) dlsym(handle, sym)


### PR DESCRIPTION
Update gpu.go initGPUHandles() to declare gpuHandles variable before reading it. This resolves an "invalid memory address or nil pointer dereference" error.

Update dyn_ext_server.c to avoid setting the RTLD_DEEPBIND flag under __TERMUX__ (Android).