### PR TITLE
add Open Interpreter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,3 +321,4 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Rivet plugin](https://github.com/abrenneke/rivet-plugin-ollama)
 - [Llama Coder](https://github.com/ex3ndr/llama-coder) (Copilot alternative using Ollama)
 - [Obsidian BMO Chatbot plugin](https://github.com/longy2k/obsidian-bmo-chatbot)
+- [Open Interpreter](https://docs.openinterpreter.com/language-model-setup/local-models/ollama)


### PR DESCRIPTION
Adding Open Interpreter to the list of Extensions & Plugins. Includes link to OI documentation explaining how to use Ollama to power OI