### PR TITLE
fix: cache prompt causes kv cache to fill and not return after some time

### DIFF
--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -181,7 +181,6 @@ func (llm *dynExtServer) Predict(ctx context.Context, predict PredictOpts, fn fu
 		"seed":              predict.Options.Seed,
 		"stop":              predict.Options.Stop,
 		"image_data":        imageData,
-		"cache_prompt":      true,
 	}
 
 	if predict.Format == "json" {


### PR DESCRIPTION
- prompt cache causes inferance to hang after some time

This is a temporary fix to mitigate #1994 if I can't fix the root cause before the next release.