### PR TITLE
fix: normalize name path before splitting

### DIFF
--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -46,6 +46,7 @@ func ParseModelPath(name string) ModelPath {
 		name = after
 	}
 
+	name = strings.ReplaceAll(name, string(os.PathSeparator), "/")
 	parts := strings.Split(name, "/")
 	switch len(parts) {
 	case 3:


### PR DESCRIPTION
During pruning input to ParseModelPath is a file path which on Windows will cause the split to not work as expected. It's still necessary to split on `/` because the most common case is a URL path which is platform agnostic