### PR TITLE
Unlock mutex when failing to load model

### DIFF
--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -141,6 +141,7 @@ func newDynExtServer(library, model string, adapters, projectors []string, opts 
 	defer freeExtServerResp(initResp)
 	C.dyn_llama_server_init(llm.s, &sparams, &initResp)
 	if initResp.id < 0 {
+		mutex.Unlock()
 		return nil, extServerResponseToErr(initResp)
 	}
 


### PR DESCRIPTION
Avoids `ollama serve` hanging with `concurrent llm servers not yet supported, waiting for prior server to complete` when a model fails to load

I believe this also fixes https://github.com/jmorganca/ollama/issues/1641