### PR TITLE
readline: drop not use min function

### DIFF
--- a/readline/buffer.go
+++ b/readline/buffer.go
@@ -133,13 +133,6 @@ func (b *Buffer) Size() int {
 	return b.Buf.Size()
 }
 
-func min(n, m int) int {
-	if n > m {
-		return m
-	}
-	return n
-}
-
 func (b *Buffer) Add(r rune) {
 	if b.Pos == b.Buf.Size() {
 		fmt.Printf("%c", r)


### PR DESCRIPTION
Since [Go1.21 (go.mod)](https://go.dev/doc/go1.21), Go adds min builtin function.