### PR TITLE
Update README.md - Community Integrations - Obsidian Local GPT plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,4 +327,5 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Rivet plugin](https://github.com/abrenneke/rivet-plugin-ollama)
 - [Llama Coder](https://github.com/ex3ndr/llama-coder) (Copilot alternative using Ollama)
 - [Obsidian BMO Chatbot plugin](https://github.com/longy2k/obsidian-bmo-chatbot)
+- [Obsidian Local GPT plugin](https://github.com/pfrankov/obsidian-local-gpt)
 - [Open Interpreter](https://docs.openinterpreter.com/language-model-setup/local-models/ollama)


### PR DESCRIPTION
Local GPT plugin for Obsidian mainly relies on Ollama provider

![image](https://github.com/pfrankov/obsidian-local-gpt/assets/584632/724d4399-cb6c-4531-9f04-a1e5df2e3dad)

Also works with images  
<img width="400" src="https://github.com/pfrankov/obsidian-local-gpt/assets/584632/a05d68fa-5419-4386-ac43-82b9513999ad">  

<img width="598" alt="Settings" src="https://github.com/pfrankov/obsidian-local-gpt/assets/584632/6ab2d802-13ed-42be-aab1-6a3f689b18a0">

I'd say that Local GPT plugin is enhanced version of [Obsidian Ollama plugin](https://github.com/hinterdupfinger/obsidian-ollama) in every way.

Tried to resolve merge conflicts in https://github.com/jmorganca/ollama/pull/1662 but accidentally closed it.