### PR TITLE
Debug logging on init failure

### DIFF
--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -142,7 +142,9 @@ func newDynExtServer(library, model string, adapters, projectors []string, opts 
 	C.dyn_llama_server_init(llm.s, &sparams, &initResp)
 	if initResp.id < 0 {
 		mutex.Unlock()
-		return nil, extServerResponseToErr(initResp)
+		err := extServerResponseToErr(initResp)
+		slog.Debug(fmt.Sprintf("failure during initialization: %s", err))
+		return nil, err
 	}
 
 	slog.Info("Starting llama main loop")


### PR DESCRIPTION
One class of error we're seeing on ROCm looks like this in the log...
```
2024/01/21 22:00:15 dyn_ext_server.go:90: INFO Loading Dynamic llm server: /tmp/ollama1546965028/rocm_v5/libext_server.so
2024/01/21 22:00:15 dyn_ext_server.go:139: INFO Initializing llama server
free(): invalid pointer
```

I'm not sure yet what the root cause is, but hopefully this debug log will yield some more insight.