### PR TITLE
Set a default version using git describe

### DIFF
--- a/scripts/build_darwin.sh
+++ b/scripts/build_darwin.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export VERSION=${VERSION:-0.0.0}
+export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
 export GOFLAGS="'-ldflags=-w -s \"-X=github.com/jmorganca/ollama/version.Version=$VERSION\" \"-X=github.com/jmorganca/ollama/server.mode=release\"'"
 
 mkdir -p dist

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-export VERSION=${VERSION:-0.0.0}
+export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
 export GOFLAGS="'-ldflags=-w -s \"-X=github.com/jmorganca/ollama/version.Version=$VERSION\" \"-X=github.com/jmorganca/ollama/server.mode=release\"'"
 
 docker build \

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-export VERSION=${VERSION:-0.0.0}
+export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
 export GOFLAGS="'-ldflags=-w -s \"-X=github.com/jmorganca/ollama/version.Version=$VERSION\" \"-X=github.com/jmorganca/ollama/server.mode=release\"'"
 
 BUILD_ARCH=${BUILD_ARCH:-"amd64 arm64"}


### PR DESCRIPTION
If a VERSION is not specified, this will generate a version string that represents the state of the repo.  For example `0.1.21-12-gffaf52e-dirty` representing 12 commits away from 0.1.21 tag, on commit gffaf52e and the tree is dirty.